### PR TITLE
Move browser and all its related stuff from MochaRunner to MochaAdapter

### DIFF
--- a/lib/runner/mocha-runner/index.js
+++ b/lib/runner/mocha-runner/index.js
@@ -1,9 +1,7 @@
 'use strict';
 
 var MochaAdapter = require('./mocha-adapter'),
-    ProxyReporter = require('./proxy-reporter'),
     utils = require('q-promise-utils'),
-    logger = require('../../utils').logger,
     QEmitter = require('qemitter'),
 
     _ = require('lodash'),
@@ -13,7 +11,6 @@ var MochaRunner = inherit(QEmitter, {
     __constructor: function(config, browserAgent) {
         this._sharedMochaOpts = config.mochaOpts;
         this._browserAgent = browserAgent;
-        this._browser = null;
     },
 
     run: function(suitePaths, filterFn) {
@@ -27,72 +24,14 @@ var MochaRunner = inherit(QEmitter, {
     },
 
     _createMocha: function(suiteFile, filterFn) {
-        var mocha = new MochaAdapter(this._sharedMochaOpts);
-        mocha.addFile(suiteFile);
-
-        this._attachBrowser(mocha.suite);
-        this._attachTestFilter(mocha.suite, filterFn);
-        this._listenMochaEvents(mocha);
-
-        return mocha;
-    },
-
-    _attachBrowser: function(suite) {
-        var _this = this,
-            savedEnableTimeouts = suite.enableTimeouts();
-
-        suite.enableTimeouts(false);
-
-        suite.beforeAll(function() {
-            return _this._browserAgent.getBrowser()
-                .then(function(browser) {
-                    _this._browser = browser;
-                    suite.ctx.browser = browser.publicAPI;
-                });
-        });
-
-        suite.afterAll(function() {
-            return _this._browser
-                && _this._browserAgent.freeBrowser(_this._browser)
-                    .catch(function(e) {
-                        logger.warn('WARNING: can not release browser: ' + e);
-                    });
-        }.bind(this));
-
-        suite.enableTimeouts(savedEnableTimeouts);
-    },
-
-    _attachTestFilter: function(suite, shouldRunTest) {
-        var browser = this._browserAgent.browserId;
-
-        listenSuite_(suite);
-
-        function listenSuite_(suite) {
-            suite.on('suite', listenSuite_);
-            suite.on('test', filterTest_);
-        }
-
-        function filterTest_(test) {
-            if (!shouldRunTest(test, browser)) {
-                test.parent.tests.pop();
-            }
-        }
-    },
-
-    getBrowser: function() {
-        return this._browser;
-    },
-
-    _listenMochaEvents: function(mocha, getBrowser) {
-        mocha.reporter(ProxyReporter, {
-            browserId: this._browserAgent.browserId,
-            getBrowser: this.getBrowser.bind(this),
-            emit: this.emit.bind(this)
-        });
+        return new MochaAdapter(this._sharedMochaOpts, this._browserAgent)
+            .addFile(suiteFile)
+            .attachTestFilter(filterFn)
+            .attachEmitFn(this.emit.bind(this));
     }
 }, {
-    create: function(config, browser) {
-        return new MochaRunner(config, browser);
+    create: function(config, browserAgent) {
+        return new MochaRunner(config, browserAgent);
     }
 });
 

--- a/lib/runner/mocha-runner/mocha-adapter.js
+++ b/lib/runner/mocha-runner/mocha-adapter.js
@@ -1,6 +1,8 @@
 'use strict';
 
-var inherit = require('inherit'),
+var ProxyReporter = require('./proxy-reporter'),
+    logger = require('../../utils').logger,
+    inherit = require('inherit'),
     Mocha = require('mocha'),
     path = require('path'),
     clearRequire = require('clear-require'),
@@ -12,10 +14,14 @@ var inherit = require('inherit'),
 process.setMaxListeners(0);
 
 module.exports = inherit({
-    __constructor: function(opts) {
+    __constructor: function(opts, browserAgent) {
         this._mocha = new Mocha(opts);
         this._mocha.fullTrace();
         this.suite = this._mocha.suite;
+
+        this._browserAgent = browserAgent;
+        this._browser = null;
+        this._attachBrowser();
     },
 
     addFile: function(file) {
@@ -23,10 +29,66 @@ module.exports = inherit({
         this._mocha.addFile(file);
         this._mocha.loadFiles();
         this._mocha.files = [];
+
+        return this;
     },
 
-    reporter: function(reporter, opts) {
-        this._mocha.reporter(reporter, opts);
+    _attachBrowser: function() {
+        var savedEnableTimeouts = this.suite.enableTimeouts();
+
+        this.suite.enableTimeouts(false);
+
+        this.suite.beforeAll(this._requestBrowser.bind(this));
+        this.suite.afterAll(this._freeBrowser.bind(this));
+
+        this.suite.enableTimeouts(savedEnableTimeouts);
+    },
+
+    _requestBrowser: function() {
+        return this._browserAgent.getBrowser()
+            .then(function(browser) {
+                this._browser = browser;
+                this.suite.ctx.browser = browser.publicAPI;
+            }.bind(this));
+    },
+
+    _freeBrowser: function() {
+        return this._browser
+            && this._browserAgent.freeBrowser(this._browser)
+                .catch(function(e) {
+                    logger.warn('WARNING: can not release browser: ' + e);
+                });
+    },
+
+    attachTestFilter: function(shouldRunTest) {
+        var browser = this._browserAgent.browserId;
+
+        listenSuite_(this.suite);
+        return this;
+
+        function listenSuite_(suite) {
+            suite.on('suite', listenSuite_);
+            suite.on('test', filterTest_);
+        }
+
+        function filterTest_(test) {
+            if (!shouldRunTest(test, browser)) {
+                test.parent.tests.pop();
+            }
+        }
+    },
+
+    attachEmitFn: function(emit) {
+        this._mocha.reporter(ProxyReporter, {
+            getBrowser: this._getBrowser.bind(this),
+            emit: emit
+        });
+
+        return this;
+    },
+
+    _getBrowser: function() {
+        return this._browser || {id: this._browserAgent.browserId};
     },
 
     run: function() {

--- a/lib/runner/mocha-runner/proxy-reporter.js
+++ b/lib/runner/mocha-runner/proxy-reporter.js
@@ -21,7 +21,6 @@ module.exports = inherit(mocha.reporters.Base, {
         this.__base(runner);
         this._emit = options.reporterOptions.emit;
         this._getBrowser = options.reporterOptions.getBrowser;
-        this._browserId = options.reporterOptions.browserId;
 
         this._listenEvents(runner);
     },
@@ -86,8 +85,8 @@ module.exports = inherit(mocha.reporters.Base, {
         var browser = this._getBrowser();
 
         return _.extend(data, {
-            sessionId: browser && browser.sessionId,
-            browserId: this._browserId
+            sessionId: browser.sessionId,
+            browserId: browser.id
         });
     }
 });

--- a/test/lib/runner/mocha-runner/index.js
+++ b/test/lib/runner/mocha-runner/index.js
@@ -1,43 +1,25 @@
 'use strict';
 
-var q = require('q'),
-    _ = require('lodash'),
-    EventEmitter = require('events').EventEmitter,
-    BrowserAgent = require('../../../../lib/browser-agent'),
-    logger = require('../../../../lib/utils').logger,
+var BrowserAgent = require('../../../../lib/browser-agent'),
     MochaAdapter = require('../../../../lib/runner/mocha-runner/mocha-adapter'),
-    ProxyReporter = require('../../../../lib/runner/mocha-runner/proxy-reporter'),
-    MochaRunner = require('../../../../lib/runner/mocha-runner');
+    MochaRunner = require('../../../../lib/runner/mocha-runner'),
+    q = require('q');
 
 describe('mocha-runner', function() {
     var sandbox = sinon.sandbox.create();
 
-    function mkSuiteStub_() {
-        var suite = new EventEmitter();
-
-        suite.enableTimeouts = sandbox.stub();
-        suite.beforeAll = sandbox.stub();
-        suite.afterAll = sandbox.stub();
-        suite.tests = [];
-
-        return suite;
-    }
-
     function run_(suites, filterFn) {
         return new MochaRunner(
             {mochaOpts: {}},
-            new BrowserAgent()
+            sinon.createStubInstance(BrowserAgent)
         ).run(suites || ['test_suite'], filterFn);
     }
 
     beforeEach(function() {
         sandbox.stub(MochaAdapter.prototype);
-        MochaAdapter.prototype.suite = mkSuiteStub_();
-
-        sandbox.stub(BrowserAgent.prototype);
-        BrowserAgent.prototype.browserId = 'some-default-browser';
-
-        sandbox.stub(logger);
+        MochaAdapter.prototype.addFile.returnsThis();
+        MochaAdapter.prototype.attachTestFilter.returnsThis();
+        MochaAdapter.prototype.attachEmitFn.returnsThis();
     });
 
     afterEach(function() {
@@ -65,151 +47,6 @@ describe('mocha-runner', function() {
                         MochaAdapter.prototype.__constructor.secondCall.args[0]
                     );
                 });
-        });
-
-        it('should request browser before suite execution', function() {
-            MochaAdapter.prototype.suite.beforeAll.yields();
-            BrowserAgent.prototype.getBrowser.returns(q());
-
-            return run_()
-                .then(function() {
-                    assert.calledOnce(BrowserAgent.prototype.getBrowser);
-                });
-        });
-
-        it('should release browser after suite execution', function() {
-            var browser = {};
-
-            MochaAdapter.prototype.suite.beforeAll.yields();
-
-            BrowserAgent.prototype.getBrowser.returns(q(browser));
-            BrowserAgent.prototype.freeBrowser.returns(q());
-
-            return run_()
-                .then(function() {
-                    var afterAll = MochaAdapter.prototype.suite.afterAll.firstCall.args[0];
-                    return afterAll();
-                })
-                .then(function() {
-                    assert.calledOnce(BrowserAgent.prototype.freeBrowser);
-                    assert.calledWith(BrowserAgent.prototype.freeBrowser, browser);
-                });
-        });
-
-        it('should disable mocha timeouts while setting browser hooks', function() {
-            MochaAdapter.prototype.suite.enableTimeouts.onFirstCall().returns(true);
-
-            return run_()
-                .then(function() {
-                    assert.callOrder(
-                        MochaAdapter.prototype.suite.enableTimeouts, // get current value of enableTimeouts
-                        MochaAdapter.prototype.suite.enableTimeouts.withArgs(false).named('disableTimeouts'),
-                        MochaAdapter.prototype.suite.beforeAll,
-                        MochaAdapter.prototype.suite.afterAll,
-                        MochaAdapter.prototype.suite.enableTimeouts.withArgs(true).named('restoreTimeouts')
-                    );
-                });
-        });
-
-        it('should not be rejected if freeBrowser failed', function() {
-            var browser = {};
-
-            MochaAdapter.prototype.suite.beforeAll.yields();
-
-            BrowserAgent.prototype.getBrowser.returns(q(browser));
-            BrowserAgent.prototype.freeBrowser.returns(q.reject('some-error'));
-
-            return run_()
-                .then(function() {
-                    var afterAll = MochaAdapter.prototype.suite.afterAll.firstCall.args[0];
-                    return assert.isFulfilled(afterAll());
-                })
-                .then(function() {
-                    assert.calledOnce(logger.warn);
-                    assert.calledWithMatch(logger.warn, /some-error/);
-                });
-        });
-
-        it('should set mocha reporter as proxy reporter in order to proxy events from mocha to runner', function() {
-            return run_()
-                .then(function() {
-                    assert.calledWith(MochaAdapter.prototype.reporter, ProxyReporter);
-                });
-        });
-
-        it('should pass to proxy reporter browser id', function() {
-            BrowserAgent.prototype.browserId = 'browser';
-
-            return run_()
-                .then(function() {
-                    assert.calledWithMatch(MochaAdapter.prototype.reporter, sinon.match.any, {
-                        browserId: 'browser'
-                    });
-                });
-        });
-
-        it('should pass to proxy reporter getter for requested browser', function() {
-            var browser = {};
-
-            MochaAdapter.prototype.suite.beforeAll.yields();
-            BrowserAgent.prototype.getBrowser.returns(q(browser));
-
-            return run_()
-                .then(function() {
-                    var getBrowser = MochaAdapter.prototype.reporter.lastCall.args[1].getBrowser;
-                    assert.equal(browser, getBrowser());
-                });
-        });
-
-        describe('filterFn', function() {
-            function mkTestStub_(opts) {
-                return _.defaults(opts || {}, {
-                    title: 'default-title',
-                    parent: MochaAdapter.prototype.suite
-                });
-            }
-
-            it('should check if test should be run', function() {
-                var someTest = mkTestStub_(),
-                    shouldRun = sandbox.stub().returns(true);
-
-                MochaAdapter.prototype.suite.tests = [someTest];
-                BrowserAgent.prototype.browserId = 'some-browser';
-
-                return run_(null, shouldRun)
-                    .then(function() {
-                        MochaAdapter.prototype.suite.emit('test', someTest);
-                        assert.calledWith(shouldRun, someTest, 'some-browser');
-                    });
-            });
-
-            it('should not remove test which expected to be run', function() {
-                var test1 = mkTestStub_(),
-                    test2 = mkTestStub_(),
-                    shouldRun = sandbox.stub().returns(true);
-
-                MochaAdapter.prototype.suite.tests = [test1, test2];
-
-                return run_(null, shouldRun)
-                    .then(function() {
-                        MochaAdapter.prototype.suite.emit('test', test2);
-                        assert.deepEqual(MochaAdapter.prototype.suite.tests, [test1, test2]);
-                    });
-            });
-
-            it('should remove test which does not suppose to be run', function() {
-                var test1 = mkTestStub_(),
-                    test2 = mkTestStub_(),
-                    shouldRun = sandbox.stub().returns(false);
-
-                MochaAdapter.prototype.suite.tests = [test1, test2];
-
-                return run_(null, shouldRun)
-                    .then(function() {
-                        MochaAdapter.prototype.suite.emit('test', test2);
-                        assert.deepEqual(MochaAdapter.prototype.suite.tests, [test1]);
-                    });
-            });
         });
 
         it('should run all mocha instances', function() {

--- a/test/lib/runner/mocha-runner/proxy-reporter.js
+++ b/test/lib/runner/mocha-runner/proxy-reporter.js
@@ -3,7 +3,7 @@
 var EventEmitter = require('events').EventEmitter,
     ProxyReporter = require('../../../../lib/runner/mocha-runner/proxy-reporter');
 
-describe('Proxy reporter', function() {
+describe('mocha-runner/proxy-reporter', function() {
     var sandbox = sinon.sandbox.create(),
         runner,
         emit;
@@ -12,9 +12,9 @@ describe('Proxy reporter', function() {
         return new ProxyReporter(runner, {
             reporterOptions: {
                 emit: emit,
-                browserId: browserId || 'default-browser',
                 getBrowser: sinon.stub().returns({
-                    sessionId: sessionId || 'default-session-id'
+                    sessionId: sessionId || 'default-session-id',
+                    id: browserId || 'default-browser'
                 })
             }
         });


### PR DESCRIPTION
После [вот этого коммита](https://github.com/gemini-testing/hermione/commit/f4404d060a58671a6de1ed09d5236416d559504f) параллельный запуск в одном браузере сломался, т.к. порвалась связь `один файл` <-> `одна сессия`, и при каждом старте новой сессии она перетиралась.

Здесь я сместил всю эту логику из `MochaRunner` в `MochaAdapter`, и теперь эта связь восстановлена.

Смотреть, в общем-то, не на что, просто переместил код, с минимальными изменениями