### PR TITLE
Fix: do not share reporterOptions between mocha adapters

### DIFF
--- a/lib/runner/mocha-runner/mocha-adapter.js
+++ b/lib/runner/mocha-runner/mocha-adapter.js
@@ -6,7 +6,8 @@ var ProxyReporter = require('./proxy-reporter'),
     Mocha = require('mocha'),
     path = require('path'),
     clearRequire = require('clear-require'),
-    q = require('q');
+    q = require('q'),
+    _ = require('lodash');
 
 // Avoid mochajs warning about possible EventEmitter memory leak
 // https://nodejs.org/docs/latest/api/events.html#events_emitter_setmaxlisteners_n
@@ -79,10 +80,8 @@ module.exports = inherit({
     },
 
     attachEmitFn: function(emit) {
-        this._mocha.reporter(ProxyReporter, {
-            getBrowser: this._getBrowser.bind(this),
-            emit: emit
-        });
+        var Reporter = _.partial(ProxyReporter, emit, this._getBrowser.bind(this));
+        this._mocha.reporter(Reporter);
 
         return this;
     },

--- a/lib/runner/mocha-runner/proxy-reporter.js
+++ b/lib/runner/mocha-runner/proxy-reporter.js
@@ -17,10 +17,10 @@ var MochaEvents = {
 };
 
 module.exports = inherit(mocha.reporters.Base, {
-    __constructor: function(runner, options) {
+    __constructor: function(emit, getBrowser, runner) {
         this.__base(runner);
-        this._emit = options.reporterOptions.emit;
-        this._getBrowser = options.reporterOptions.getBrowser;
+        this._emit = emit;
+        this._getBrowser = getBrowser;
 
         this._listenEvents(runner);
     },

--- a/test/lib/runner/mocha-runner/proxy-reporter.js
+++ b/test/lib/runner/mocha-runner/proxy-reporter.js
@@ -9,15 +9,11 @@ describe('mocha-runner/proxy-reporter', function() {
         emit;
 
     function createReporter_(browserId, sessionId) {
-        return new ProxyReporter(runner, {
-            reporterOptions: {
-                emit: emit,
-                getBrowser: sinon.stub().returns({
-                    sessionId: sessionId || 'default-session-id',
-                    id: browserId || 'default-browser'
-                })
-            }
-        });
+        var getBrowser = sinon.stub().returns({
+                sessionId: sessionId || 'default-session-id',
+                id: browserId || 'default-browser'
+            });
+        return new ProxyReporter(emit, getBrowser, runner);
     }
 
     function testTranslateEvent_(from, to) {


### PR DESCRIPTION
Do not use reporterOptions because they will be shared between all adapters