### PR TITLE
Q has no method 'getUnhandledReasons'

### DIFF
--- a/lib/hermione.js
+++ b/lib/hermione.js
@@ -6,9 +6,7 @@ var Runner = require('./runner'),
     pathUtils = require('./path-utils'),
     logger = require('./utils').logger,
     _ = require('lodash'),
-    q = require('q'),
     inherit = require('inherit'),
-    qDebugMode = require('q-debug-mode'),
     util = require('util'),
     chalk = require('chalk');
 
@@ -28,10 +26,6 @@ module.exports = inherit({
 
     run: function(testPaths, browsers) {
         browsers = this._filterBrowsers(browsers, _.keys(this._config.browsers));
-
-        if (this._config.debug) {
-            qDebugMode(q);
-        }
 
         var runner = Runner.create(this._config);
         runner.on(RunnerEvents.TEST_FAIL, this._fail.bind(this));

--- a/package.json
+++ b/package.json
@@ -31,7 +31,6 @@
     "lodash": "~3.10.1",
     "mocha": "~2.4.5",
     "q": "^2.0.0",
-    "q-debug-mode": "0.0.1",
     "q-io": "^2.0.6",
     "q-promise-utils": "^1.0.0",
     "teamcity-service-messages": "^0.1.6",


### PR DESCRIPTION
When I specified `debug` option in the config file, I'll got the following error:
```javascript
TypeError: Object function Q(value) {
   // If the object is already a Promise, return it directly.  This enables
   // the resolve function to both be used to created references from objects,
   // but to tolerably coerce non-promises to promises.
   if (Q_isPromise(value)) {
       return value;
   } else if (isThenable(value)) {
       if (!thenables.has(value)) {
           thenables.set(value, new Promise(new Thenable(value)));
       }
       return thenables.get(value);
   } else {
       return new Promise(new Fulfilled(value));
   }
} has no method 'getUnhandledReasons'
```

`hermione` uses q library v2 which doesn't have `getUnhandledReasons` method anymore. 
It seems that `q-debug-mode` is useless now and can be pruned.

/cc @j0tunn