### PR TITLE
Attach execution context to browser

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,6 +19,9 @@ Hermione is the utility for integration testing of web pages using [WebdriverIO]
   - [Auto initialization and closing grid sessions](#auto-initialization-and-closing-grid-sessions)
 - [Prerequisites](#prerequisites)
 - [Skip](#skip)
+- [WebdriverIO extensions](#webdriverio-extensions)
+  - [Sharable meta info](#sharable-meta-info)
+  - [Execution context](#execution-context)
 - [Quick start](#quick-start)
 - [.hermione.conf.js](#hermioneconfjs)
   - [specs](#specs)
@@ -188,18 +191,21 @@ it('test1', () => doSomething());
 
 If you need to skip test in all browsers without a comment you can use [mocha `.skip` method](http://mochajs.org/#inclusive-tests) instead of `hermione.skip.in(/.*/);`. The result will be the same.
 
-## Sharable meta info
-On initialization hermione adds two commands to the webdriverio instance:
+## WebdriverIO extensions
+`Hermione` adds some usefull methods and properties to the `webdriverio` session after its initialization.
+
+### Sharable meta info
+Implemented via two commands:
 * setMeta(key, value)
 * getMeta(key)
 
 These methods allow to store some information between webdriver calls so it can be used in custom commands for example. This meta information will be shown in [allure report](https://github.com/gemini-testing/hermione-allure-reporter).
 
-**Note**: hermione saves in meta info last url (without origin) opened in browser.
+**Note**: hermione saves in meta info last url opened in browser.
 
 Example:
 ```js
-it('test1', () => {
+it('test1', function() {
     return this.browser
         .setMeta('foo', 'bar')
         .url('/foo/bar?baz=qux')
@@ -208,6 +214,38 @@ it('test1', () => {
         .getMeta('url')
         .then((url) => console.log(url)); // prints '/foo/bar?baz=qux'
 });
+```
+
+### Execution context
+Execution context can be accessed by `browser.executionContext` property which contains current test/hook mocha object extended with browser id.
+
+Example:
+```js
+it('some test', function() {
+    return this.browser
+        .url('/foo/bar')
+        .then(function() {
+            console.log('test', this.executionContext);
+        });
+});
+```
+will print something like this
+```
+test: {
+  "title": "some test",
+  "async": 0,
+  "sync": true,
+  "timedOut": false,
+  "pending": false,
+  "type": "test",
+  "body": "...",
+  "file": "/foo/bar/baz/qux.js",
+  "parent": "#<Suite>",
+  "ctx": "#<Context>",
+  "browserId": "chrome",
+  "meta": {},
+  "timer": {}
+}
 ```
 
 ## Quick start

--- a/lib/runner/mocha-runner/index.js
+++ b/lib/runner/mocha-runner/index.js
@@ -24,7 +24,7 @@ var MochaRunner = inherit(QEmitter, {
     },
 
     _createMocha: function(suiteFile, filterFn) {
-        return new MochaAdapter(this._sharedMochaOpts, this._browserAgent)
+        return MochaAdapter.create(this._sharedMochaOpts, this._browserAgent)
             .attachTestFilter(filterFn)
             .addFile(suiteFile)
             .attachEmitFn(this.emit.bind(this));

--- a/lib/runner/mocha-runner/mocha-adapter.js
+++ b/lib/runner/mocha-runner/mocha-adapter.js
@@ -28,8 +28,11 @@ module.exports = class MochaAdapter {
         this._browserAgent = browserAgent;
         this._browser = null;
 
+        this._currentRunnable = null;
+
         this._injectBrowser();
         this._injectSkip();
+        this._injectRunnableSpy();
     }
 
     addFile(file) {
@@ -45,7 +48,7 @@ module.exports = class MochaAdapter {
     attachTestFilter(shouldRunTest) {
         const browserId = this._browserAgent.browserId;
 
-        this._setEventHandler('test', (test) => shouldRunTest(test, browserId) || test.parent.tests.pop());
+        this._addEventHandler('test', (test) => shouldRunTest(test, browserId) || test.parent.tests.pop());
 
         return this;
     }
@@ -71,11 +74,31 @@ module.exports = class MochaAdapter {
         });
         this.suite.on('post-require', () => delete global.hermione);
 
-        this._setEventHandler(['suite', 'test'], (runnable) => skip.handleEntity(runnable));
+        this._addEventHandler(['suite', 'test'], (runnable) => skip.handleEntity(runnable));
+    }
+
+    _injectRunnableSpy() {
+        const browserId = this._browserAgent.browserId;
+
+        this._addEventHandler(
+            ['beforeAll', 'beforeEach', 'test', 'afterEach', 'afterAll'],
+            (runnable) => {
+                const baseFn = runnable.fn;
+                if (!baseFn) {
+                    return;
+                }
+
+                const _this = this;
+                runnable.fn = function() {
+                    _this._currentRunnable = _.extend(runnable, {browserId});
+                    return baseFn.apply(this, arguments);
+                };
+            }
+        );
     }
 
     // Set recursive handler for events triggered by mocha while parsing test file
-    _setEventHandler(events, cb) {
+    _addEventHandler(events, cb) {
         events = [].concat(events);
 
         const listenSuite = (suite) => {
@@ -101,6 +124,11 @@ module.exports = class MochaAdapter {
         return this._browserAgent.getBrowser()
             .then((browser) => {
                 this._browser = browser;
+
+                Object.defineProperty(Object.getPrototypeOf(browser.publicAPI), 'executionContext', {
+                    get: () => this._currentRunnable
+                });
+
                 this.suite.ctx.browser = browser.publicAPI;
             });
     }

--- a/lib/runner/mocha-runner/mocha-adapter.js
+++ b/lib/runner/mocha-runner/mocha-adapter.js
@@ -1,23 +1,26 @@
 'use strict';
 
-var ProxyReporter = require('./proxy-reporter'),
-    logger = require('../../utils').logger,
-    Skip = require('./skip/'),
-    SkipBuilder = require('./skip/skip-builder'),
-    inherit = require('inherit'),
-    Mocha = require('mocha'),
-    path = require('path'),
-    clearRequire = require('clear-require'),
-    q = require('q'),
-    _ = require('lodash');
+const ProxyReporter = require('./proxy-reporter');
+const logger = require('../../utils').logger;
+const Skip = require('./skip/');
+const SkipBuilder = require('./skip/skip-builder');
+const Mocha = require('mocha');
+const path = require('path');
+const clearRequire = require('clear-require');
+const q = require('q');
+const _ = require('lodash');
 
 // Avoid mochajs warning about possible EventEmitter memory leak
 // https://nodejs.org/docs/latest/api/events.html#events_emitter_setmaxlisteners_n
 // Reason: each mocha runner sets 'uncaughtException' listener
 process.setMaxListeners(0);
 
-module.exports = inherit({
-    __constructor: function(opts, browserAgent) {
+module.exports = class MochaAdapter {
+    static create(opts, browserAgent) {
+        return new MochaAdapter(opts, browserAgent);
+    }
+
+    constructor(opts, browserAgent) {
         this._mocha = new Mocha(opts);
         this._mocha.fullTrace();
         this.suite = this._mocha.suite;
@@ -27,9 +30,9 @@ module.exports = inherit({
 
         this._injectBrowser();
         this._injectSkip();
-    },
+    }
 
-    addFile: function(file) {
+    addFile(file) {
         clearRequire(path.resolve(file));
 
         this._mocha.addFile(file);
@@ -37,32 +40,28 @@ module.exports = inherit({
         this._mocha.files = [];
 
         return this;
-    },
+    }
 
-    attachTestFilter: function(shouldRunTest) {
+    attachTestFilter(shouldRunTest) {
         const browserId = this._browserAgent.browserId;
 
-        this._setEventHandler('test', (test) => {
-            if (!shouldRunTest(test, browserId)) {
-                test.parent.tests.pop();
-            }
-        });
+        this._setEventHandler('test', (test) => shouldRunTest(test, browserId) || test.parent.tests.pop());
 
         return this;
-    },
+    }
 
-    attachEmitFn: function(emit) {
-        var Reporter = _.partial(ProxyReporter, emit, this._getBrowser.bind(this));
+    attachEmitFn(emit) {
+        const Reporter = _.partial(ProxyReporter, emit, () => this._getBrowser());
         this._mocha.reporter(Reporter);
 
         return this;
-    },
+    }
 
-    run: function() {
+    run() {
         return q.Promise(this._mocha.run.bind(this._mocha));
-    },
+    }
 
-    _injectSkip: function() {
+    _injectSkip() {
         const skip = new Skip();
 
         this.suite.on('pre-require', () => {
@@ -73,10 +72,10 @@ module.exports = inherit({
         this.suite.on('post-require', () => delete global.hermione);
 
         this._setEventHandler(['suite', 'test'], (runnable) => skip.handleEntity(runnable));
-    },
+    }
 
-    // Set recursive handler for events triggered by mocha while parsing test files
-    _setEventHandler: function(events, cb) {
+    // Set recursive handler for events triggered by mocha while parsing test file
+    _setEventHandler(events, cb) {
         events = [].concat(events);
 
         const listenSuite = (suite) => {
@@ -85,36 +84,34 @@ module.exports = inherit({
         };
 
         listenSuite(this.suite);
-    },
+    }
 
-    _injectBrowser: function() {
-        var savedEnableTimeouts = this.suite.enableTimeouts();
+    _injectBrowser() {
+        const savedEnableTimeouts = this.suite.enableTimeouts();
 
         this.suite.enableTimeouts(false);
 
-        this.suite.beforeAll(this._requestBrowser.bind(this));
-        this.suite.afterAll(this._freeBrowser.bind(this));
+        this.suite.beforeAll(() => this._requestBrowser());
+        this.suite.afterAll(() => this._freeBrowser());
 
         this.suite.enableTimeouts(savedEnableTimeouts);
-    },
+    }
 
-    _requestBrowser: function() {
+    _requestBrowser() {
         return this._browserAgent.getBrowser()
-            .then(function(browser) {
+            .then((browser) => {
                 this._browser = browser;
                 this.suite.ctx.browser = browser.publicAPI;
-            }.bind(this));
-    },
+            });
+    }
 
-    _freeBrowser: function() {
+    _freeBrowser() {
         return this._browser
             && this._browserAgent.freeBrowser(this._browser)
-                .catch(function(e) {
-                    logger.warn('WARNING: can not release browser: ' + e);
-                });
-    },
+                .catch((e) => logger.warn('WARNING: can not release browser: ' + e));
+    }
 
-    _getBrowser: function() {
+    _getBrowser() {
         return this._browser || {id: this._browserAgent.browserId};
     }
-});
+};

--- a/lib/runner/mocha-runner/mocha-adapter.js
+++ b/lib/runner/mocha-runner/mocha-adapter.js
@@ -24,18 +24,14 @@ module.exports = inherit({
 
         this._browserAgent = browserAgent;
         this._browser = null;
-        this._attachBrowser();
-        this._skip = new Skip();
+
+        this._injectBrowser();
+        this._injectSkip();
     },
 
     addFile: function(file) {
         clearRequire(path.resolve(file));
-        this.suite.on('pre-require', () => {
-            global.hermione = {
-                skip: new SkipBuilder(this._skip, this._browserAgent.browserId)
-            };
-        });
-        this.suite.on('post-require', () => delete global.hermione);
+
         this._mocha.addFile(file);
         this._mocha.loadFiles();
         this._mocha.files = [];
@@ -43,7 +39,55 @@ module.exports = inherit({
         return this;
     },
 
-    _attachBrowser: function() {
+    attachTestFilter: function(shouldRunTest) {
+        const browserId = this._browserAgent.browserId;
+
+        this._setEventHandler('test', (test) => {
+            if (!shouldRunTest(test, browserId)) {
+                test.parent.tests.pop();
+            }
+        });
+
+        return this;
+    },
+
+    attachEmitFn: function(emit) {
+        var Reporter = _.partial(ProxyReporter, emit, this._getBrowser.bind(this));
+        this._mocha.reporter(Reporter);
+
+        return this;
+    },
+
+    run: function() {
+        return q.Promise(this._mocha.run.bind(this._mocha));
+    },
+
+    _injectSkip: function() {
+        const skip = new Skip();
+
+        this.suite.on('pre-require', () => {
+            global.hermione = {
+                skip: new SkipBuilder(skip, this._browserAgent.browserId)
+            };
+        });
+        this.suite.on('post-require', () => delete global.hermione);
+
+        this._setEventHandler(['suite', 'test'], (runnable) => skip.handleEntity(runnable));
+    },
+
+    // Set recursive handler for events triggered by mocha while parsing test files
+    _setEventHandler: function(events, cb) {
+        events = [].concat(events);
+
+        const listenSuite = (suite) => {
+            suite.on('suite', listenSuite);
+            events.forEach((e) => suite.on(e, cb));
+        };
+
+        listenSuite(this.suite);
+    },
+
+    _injectBrowser: function() {
         var savedEnableTimeouts = this.suite.enableTimeouts();
 
         this.suite.enableTimeouts(false);
@@ -70,39 +114,7 @@ module.exports = inherit({
                 });
     },
 
-    attachTestFilter: function(shouldRunTest) {
-        const browserId = this._browserAgent.browserId;
-        const applySkip = entity => this._skip.handleEntity(entity);
-
-        listenSuite_(this.suite);
-        return this;
-
-        function listenSuite_(suite) {
-            suite.on('suite', listenSuite_);
-            suite.on('test', filterTest_);
-            suite.on('suite', applySkip);
-            suite.on('test', applySkip);
-        }
-
-        function filterTest_(test) {
-            if (!shouldRunTest(test, browserId)) {
-                test.parent.tests.pop();
-            }
-        }
-    },
-
-    attachEmitFn: function(emit) {
-        var Reporter = _.partial(ProxyReporter, emit, this._getBrowser.bind(this));
-        this._mocha.reporter(Reporter);
-
-        return this;
-    },
-
     _getBrowser: function() {
         return this._browser || {id: this._browserAgent.browserId};
-    },
-
-    run: function() {
-        return q.Promise(this._mocha.run.bind(this._mocha));
     }
 });

--- a/test/lib/runner/mocha-runner/mocha-adapter.js
+++ b/test/lib/runner/mocha-runner/mocha-adapter.js
@@ -1,17 +1,17 @@
 'use strict';
 
-var BrowserAgent = require('../../../../lib/browser-agent'),
-    logger = require('../../../../lib/utils').logger,
-    ProxyReporter = require('../../../../lib/runner/mocha-runner/proxy-reporter'),
-    SkipBuilder = require('../../../../lib/runner/mocha-runner/skip/skip-builder'),
-    Skip = require('../../../../lib/runner/mocha-runner/skip/'),
-    proxyquire = require('proxyquire').noCallThru(),
-    inherit = require('inherit'),
-    _ = require('lodash'),
-    EventEmitter = require('events').EventEmitter,
-    q = require('q');
+const BrowserAgent = require('../../../../lib/browser-agent');
+const logger = require('../../../../lib/utils').logger;
+const ProxyReporter = require('../../../../lib/runner/mocha-runner/proxy-reporter');
+const SkipBuilder = require('../../../../lib/runner/mocha-runner/skip/skip-builder');
+const Skip = require('../../../../lib/runner/mocha-runner/skip/');
+const proxyquire = require('proxyquire').noCallThru();
+const inherit = require('inherit');
+const _ = require('lodash');
+const EventEmitter = require('events').EventEmitter;
+const q = require('q');
 
-var MochaStub = inherit({
+const MochaStub = inherit({
     __constructor: _.noop,
     run: _.noop,
     fullTrace: _.noop,
@@ -20,22 +20,21 @@ var MochaStub = inherit({
     reporter: _.noop
 });
 
-describe('mocha-runner/mocha-adapter', function() {
-    var sandbox = sinon.sandbox.create(),
-        MochaAdapter,
-        browserAgent,
-        clearRequire;
+describe('mocha-runner/mocha-adapter', () => {
+    const sandbox = sinon.sandbox.create();
+
+    let MochaAdapter;
+    let browserAgent;
+    let clearRequire;
 
     function mkSuiteStub_() {
-        var suite = new EventEmitter();
-
-        suite.enableTimeouts = sandbox.stub();
-        suite.beforeAll = sandbox.stub();
-        suite.afterAll = sandbox.stub();
-        suite.tests = [];
-        suite.ctx = {};
-
-        return suite;
+        return _.extend(new EventEmitter(), {
+            enableTimeouts: sandbox.stub(),
+            beforeAll: sandbox.stub(),
+            afterAll: sandbox.stub(),
+            tests: [],
+            ctx: {}
+        });
     }
 
     function mkTestStub_(opts) {
@@ -45,9 +44,9 @@ describe('mocha-runner/mocha-adapter', function() {
         });
     }
 
-    const mkMochaAdapter_ = () => new MochaAdapter({}, browserAgent);
+    const mkMochaAdapter_ = () => MochaAdapter.create({}, browserAgent);
 
-    beforeEach(function() {
+    beforeEach(() => {
         clearRequire = sandbox.stub().named('clear-require');
         browserAgent = sinon.createStubInstance(BrowserAgent);
 
@@ -63,31 +62,25 @@ describe('mocha-runner/mocha-adapter', function() {
         sandbox.stub(logger);
     });
 
-    afterEach(function() {
-        sandbox.restore();
-    });
+    afterEach(() => sandbox.restore());
 
-    describe('constructor', function() {
-        function instantiateMocha_(config) {
-            new MochaAdapter(config); // jshint ignore:line
-        }
-
-        it('should pass shared opts to mocha instance', function() {
-            instantiateMocha_({grep: 'foo'});
+    describe('constructor', () => {
+        it('should pass shared opts to mocha instance', () => {
+            MochaAdapter.create({grep: 'foo'});
 
             assert.calledWith(MochaStub.prototype.__constructor, {grep: 'foo'});
         });
 
-        it('should enable full stacktrace in mocha', function() {
-            instantiateMocha_();
+        it('should enable full stacktrace in mocha', () => {
+            MochaAdapter.create();
 
             assert.called(MochaStub.prototype.fullTrace);
         });
     });
 
-    describe('addFile', function() {
-        it('should add file', function() {
-            var mochaAdapter = new MochaAdapter();
+    describe('addFile', () => {
+        it('should add file', () => {
+            const mochaAdapter = MochaAdapter.create();
 
             mochaAdapter.addFile('path/to/file');
 
@@ -95,8 +88,8 @@ describe('mocha-runner/mocha-adapter', function() {
             assert.calledWith(MochaStub.prototype.addFile, 'path/to/file');
         });
 
-        it('should clear require cache for file before adding', function() {
-            var mochaAdapter = new MochaAdapter();
+        it('should clear require cache for file before adding', () => {
+            const mochaAdapter = MochaAdapter.create();
 
             mochaAdapter.addFile('path/to/file');
 
@@ -104,8 +97,8 @@ describe('mocha-runner/mocha-adapter', function() {
             assert.callOrder(clearRequire, MochaStub.prototype.addFile);
         });
 
-        it('should load files after add', function() {
-            var mochaAdapter = new MochaAdapter();
+        it('should load files after add', () => {
+            const mochaAdapter = MochaAdapter.create();
 
             mochaAdapter.addFile('path/to/file');
 
@@ -113,12 +106,12 @@ describe('mocha-runner/mocha-adapter', function() {
             assert.callOrder(MochaStub.prototype.addFile, MochaStub.prototype.loadFiles);
         });
 
-        it('should flush files after load', function() {
-            var mocha = new MochaStub();
+        it('should flush files after load', () => {
+            const mocha = new MochaStub();
             mocha.files = ['some/file'];
             MochaStub.prototype.__constructor.returns(mocha);
 
-            var mochaAdapter = new MochaAdapter();
+            const mochaAdapter = MochaAdapter.create();
 
             mochaAdapter.addFile('path/to/file');
 
@@ -153,8 +146,8 @@ describe('mocha-runner/mocha-adapter', function() {
         });
     });
 
-    describe('inject browser', function() {
-        it('should request browser before suite execution', function() {
+    describe('inject browser', () => {
+        it('should request browser before suite execution', () => {
             MochaStub.prototype.suite.beforeAll.yields();
             browserAgent.getBrowser.returns(q());
 
@@ -163,25 +156,25 @@ describe('mocha-runner/mocha-adapter', function() {
             assert.calledOnce(browserAgent.getBrowser);
         });
 
-        it('should release browser after suite execution', function() {
-            var browser = {};
+        it('should release browser after suite execution', () => {
+            const browser = {};
             browserAgent.getBrowser.returns(q(browser));
             browserAgent.freeBrowser.returns(q());
 
             mkMochaAdapter_();
 
-            var beforeAll = MochaStub.prototype.suite.beforeAll.firstCall.args[0],
-                afterAll = MochaStub.prototype.suite.afterAll.firstCall.args[0];
+            const beforeAll = MochaStub.prototype.suite.beforeAll.firstCall.args[0];
+            const afterAll = MochaStub.prototype.suite.afterAll.firstCall.args[0];
 
             return beforeAll()
                 .then(afterAll)
-                .then(function() {
+                .then(() => {
                     assert.calledOnce(browserAgent.freeBrowser);
                     assert.calledWith(browserAgent.freeBrowser, browser);
                 });
         });
 
-        it('should disable mocha timeouts while setting browser hooks', function() {
+        it('should disable mocha timeouts while setting browser hooks', () => {
             MochaStub.prototype.suite.enableTimeouts.onFirstCall().returns(true);
 
             mkMochaAdapter_();
@@ -195,20 +188,20 @@ describe('mocha-runner/mocha-adapter', function() {
             );
         });
 
-        it('should not be rejected if freeBrowser failed', function() {
-            var browser = {};
+        it('should not be rejected if freeBrowser failed', () => {
+            const browser = {};
 
             browserAgent.getBrowser.returns(q(browser));
             browserAgent.freeBrowser.returns(q.reject('some-error'));
 
             mkMochaAdapter_();
 
-            var beforeAll = MochaStub.prototype.suite.beforeAll.firstCall.args[0],
-                afterAll = MochaStub.prototype.suite.afterAll.firstCall.args[0];
+            const beforeAll = MochaStub.prototype.suite.beforeAll.firstCall.args[0];
+            const afterAll = MochaStub.prototype.suite.afterAll.firstCall.args[0];
 
             return beforeAll()
                 .then(afterAll)
-                .then(function() {
+                .then(() => {
                     assert.calledOnce(logger.warn);
                     assert.calledWithMatch(logger.warn, /some-error/);
                 });
@@ -216,9 +209,7 @@ describe('mocha-runner/mocha-adapter', function() {
     });
 
     describe('inject skip', () => {
-        beforeEach(() => {
-            sandbox.stub(Skip.prototype, 'handleEntity');
-        });
+        beforeEach(() => sandbox.stub(Skip.prototype, 'handleEntity'));
 
         it('should apply skip to test', () => {
             const test = mkTestStub_();
@@ -242,16 +233,14 @@ describe('mocha-runner/mocha-adapter', function() {
         });
     });
 
-    describe('attachTestFilter', function() {
+    describe('attachTestFilter', () => {
         let mochaAdapter;
 
-        beforeEach(function() {
-            mochaAdapter = mkMochaAdapter_();
-        });
+        beforeEach(() => mochaAdapter = mkMochaAdapter_());
 
-        it('should check if test should be run', function() {
-            var someTest = mkTestStub_(),
-                shouldRun = sandbox.stub().returns(true);
+        it('should check if test should be run', () => {
+            const someTest = mkTestStub_();
+            const shouldRun = sandbox.stub().returns(true);
 
             MochaStub.prototype.suite.tests = [someTest];
             BrowserAgent.prototype.browserId = 'some-browser';
@@ -262,10 +251,10 @@ describe('mocha-runner/mocha-adapter', function() {
             assert.calledWith(shouldRun, someTest, 'some-browser');
         });
 
-        it('should not remove test which expected to be run', function() {
-            var test1 = mkTestStub_(),
-                test2 = mkTestStub_(),
-                shouldRun = sandbox.stub().returns(true);
+        it('should not remove test which expected to be run', () => {
+            const test1 = mkTestStub_();
+            const test2 = mkTestStub_();
+            const shouldRun = () => true;
 
             MochaStub.prototype.suite.tests = [test1, test2];
 
@@ -275,10 +264,10 @@ describe('mocha-runner/mocha-adapter', function() {
             assert.deepEqual(MochaStub.prototype.suite.tests, [test1, test2]);
         });
 
-        it('should remove test which does not suppose to be run', function() {
-            var test1 = mkTestStub_(),
-                test2 = mkTestStub_(),
-                shouldRun = sandbox.stub().returns(false);
+        it('should remove test which does not suppose to be run', () => {
+            const test1 = mkTestStub_();
+            const test2 = mkTestStub_();
+            const shouldRun = () => false;
 
             MochaStub.prototype.suite.tests = [test1, test2];
 
@@ -289,10 +278,10 @@ describe('mocha-runner/mocha-adapter', function() {
         });
     });
 
-    describe('attachEmitFn', function() {
+    describe('attachEmitFn', () => {
         let mochaAdapter;
 
-        beforeEach(function() {
+        beforeEach(() => {
             sandbox.stub(ProxyReporter.prototype, '__constructor');
             mochaAdapter = mkMochaAdapter_();
         });
@@ -300,18 +289,18 @@ describe('mocha-runner/mocha-adapter', function() {
         function attachEmitFn_(emitFn) {
             mochaAdapter.attachEmitFn(emitFn);
 
-            var Reporter = MochaStub.prototype.reporter.lastCall.args[0];
+            const Reporter = MochaStub.prototype.reporter.lastCall.args[0];
             new Reporter(); // jshint ignore:line
         }
 
-        it('should set mocha reporter as proxy reporter in order to proxy events to emit fn', function() {
+        it('should set mocha reporter as proxy reporter in order to proxy events to emit fn', () => {
             attachEmitFn_(sinon.spy());
 
             assert.calledOnce(ProxyReporter.prototype.__constructor);
         });
 
-        it('should pass to proxy reporter emit fn', function() {
-            var emitFn = sinon.spy().named('emit');
+        it('should pass to proxy reporter emit fn', () => {
+            const emitFn = sinon.spy().named('emit');
 
             attachEmitFn_(emitFn);
 
@@ -319,27 +308,27 @@ describe('mocha-runner/mocha-adapter', function() {
             assert.calledWith(ProxyReporter.prototype.__constructor, emitFn);
         });
 
-        it('should pass to proxy reporter getter for requested browser', function() {
-            var browser = {};
+        it('should pass to proxy reporter getter for requested browser', () => {
+            const browser = {};
 
             attachEmitFn_(sinon.spy());
 
             browserAgent.getBrowser.returns(q(browser));
-            var beforeAll = MochaStub.prototype.suite.beforeAll.firstCall.args[0];
+            const beforeAll = MochaStub.prototype.suite.beforeAll.firstCall.args[0];
 
             return beforeAll()
-                .then(function() {
-                    var getBrowser = ProxyReporter.prototype.__constructor.lastCall.args[1];
+                .then(() => {
+                    const getBrowser = ProxyReporter.prototype.__constructor.lastCall.args[1];
                     assert.equal(browser, getBrowser());
                 });
         });
 
-        it('should pass to proxy reporter getter for browser id if browser not requested', function() {
+        it('should pass to proxy reporter getter for browser id if browser not requested', () => {
             browserAgent.browserId = 'some-browser';
 
             attachEmitFn_(sinon.spy());
 
-            var getBrowser = ProxyReporter.prototype.__constructor.lastCall.args[1];
+            const getBrowser = ProxyReporter.prototype.__constructor.lastCall.args[1];
             assert.deepEqual(getBrowser(), {id: 'some-browser'});
         });
     });


### PR DESCRIPTION
Логика такая:
* оборачиваем коллбэки для тестов/хуков функцией, которая сохраняет текущий контекст выполнения (собственно сам тест или хук)
* в прототип сессии webdriverio дописываем геттер `executionContext`