### PR TITLE
Log failed tests at the end of reporter

### DIFF
--- a/lib/reporters/flat.js
+++ b/lib/reporters/flat.js
@@ -1,6 +1,7 @@
 'use strict';
 
 const chalk = require('chalk');
+const _ = require('lodash');
 
 const logger = require('../utils').logger;
 
@@ -16,6 +17,7 @@ const getSkipReason = (test, skipReason) => test && (getSkipReason(test.parent) 
 module.exports = class FlatReporter {
     constructor() {
         this._passed = this._failed = this._pending = this._retries = 0;
+        this._tests = [];
     }
 
     attachRunner(runner) {
@@ -39,14 +41,16 @@ module.exports = class FlatReporter {
     _onTestFail(test) {
         this._failed++;
         logger.log(ICON_FAIL + this._formatTestInfo(test));
-        this._logError(test);
+
+        this._tests.push(FlatReporter._extendTestInfo(test, {isFailed: true}));
     }
 
     _onRetry(test) {
         this._retries++;
         logger.log(ICON_RETRY + this._formatTestInfo(test));
-        this._logError(test);
         logger.log('Will be retried. Retries left: %s', chalk.yellow(test.retriesLeft));
+
+        this._tests.push(FlatReporter._extendTestInfo(test, {isFailed: false}));
     }
 
     _logError(test) {
@@ -68,6 +72,8 @@ module.exports = class FlatReporter {
             chalk.cyan(this._pending),
             chalk.yellow(this._retries)
         );
+
+        FlatReporter._logFailedTestsInfo(this._tests);
     }
 
     _onWarning(info) {
@@ -90,4 +96,43 @@ module.exports = class FlatReporter {
         return ` ${suiteName}${chalk.underline(test.title)} [${chalk.yellow(test.browserId)}` +
             `${sessionId}] - ${chalk.cyan(test.duration || 0)}ms${reason || ''}`;
     }
+
+    static _logFailedTestsInfo(tests) {
+        const failedTests = this._formatFailedTests(tests);
+
+        failedTests.forEach((test, index) => {
+            logger.log(`\n${index + 1}) ${test.title}:`);
+
+            _.forEach(test.browsers, (testCases, browser) => {
+                logger.log(`  ${browser}:`);
+
+                testCases.forEach((testCase) => {
+                    const icon = testCase.isFailed ? ICON_FAIL : ICON_RETRY;
+
+                    logger.log(`    ${icon} ${testCase.error}`);
+                });
+            });
+        });
+    }
+
+    static _formatFailedTests(tests) {
+        return _(tests)
+            .groupBy('title')
+            .mapValues((test) => _.groupBy(test, 'browser'))
+            .map((browserTests, title) => ({title, browsers: browserTests}))
+            .value();
+    }
+
+    static _extendTestInfo(test, opts) {
+        return _.extend(this._getTestInfo(test), opts);
+    }
+
+    static _getTestInfo(test) {
+        return {
+            title: test.fullTitle(),
+            browser: test.browserId,
+            error: _.get(test, 'err.stack', test.err)
+        };
+    }
+
 };

--- a/package.json
+++ b/package.json
@@ -37,7 +37,7 @@
     "qemitter": "^1.1.0",
     "teamcity-service-messages": "^0.1.6",
     "urijs": "^1.17.0",
-    "webdriverio": "4.2.4"
+    "webdriverio": "4.2.15"
   },
   "devDependencies": {
     "chai": "^3.4.1",

--- a/test/lib/reporter/flat.js
+++ b/test/lib/reporter/flat.js
@@ -76,7 +76,7 @@ describe('Flat reporter', () => {
         it('failed', () => {
             emit(RunnerEvents.TEST_FAIL, test);
 
-            const counters = getCounters_(logger.log.lastCall.args);
+            const counters = getCounters_(logger.log.secondCall.args);
 
             assert.equal(counters.failed, 1);
         });
@@ -92,7 +92,7 @@ describe('Flat reporter', () => {
         it('retries', () => {
             emit(RunnerEvents.RETRY, test);
 
-            const counters = getCounters_(logger.log.lastCall.args);
+            const counters = getCounters_(logger.log.thirdCall.args);
 
             assert.equal(counters.retries, 1);
         });
@@ -195,6 +195,78 @@ describe('Flat reporter', () => {
             const result = getDeserealizedResult(logger.log.firstCall.args[0]);
 
             assert.match(result, /reason: no comment/);
+        });
+
+        describe('failed tests report', () => {
+            it('should log correct number of failed suite', () => {
+                test = mkTestStub_();
+
+                emit(RunnerEvents.TEST_FAIL, test);
+
+                const result = chalk.stripColor(logger.log.getCall(2).args[0]);
+
+                assert.match(result, /^\n1\) .+/);
+            });
+
+            it('should log browser of failed suite', () => {
+                test = mkTestStub_({
+                    browserId: 'bro1'
+                });
+
+                emit(RunnerEvents.TEST_FAIL, test);
+
+                const result = chalk.stripColor(logger.log.getCall(3).args[0]);
+
+                assert.match(result, /bro1/);
+            });
+
+            it('should log error of failed test', () => {
+                test = mkTestStub_({
+                    err: 'some error'
+                });
+
+                emit(RunnerEvents.TEST_FAIL, test);
+
+                const result = chalk.stripColor(logger.log.getCall(4).args[0]);
+
+                assert.match(result, /some error/);
+            });
+        });
+
+        describe('retried tests report', () => {
+            it('should log correct number of retried suite', () => {
+                test = mkTestStub_();
+
+                emit(RunnerEvents.RETRY, test);
+
+                const result = chalk.stripColor(logger.log.getCall(3).args[0]);
+
+                assert.match(result, /1\) .+/);
+            });
+
+            it('should log browser of retried suite', () => {
+                test = mkTestStub_({
+                    browserId: 'bro1'
+                });
+
+                emit(RunnerEvents.RETRY, test);
+
+                const result = chalk.stripColor(logger.log.getCall(4).args[0]);
+
+                assert.match(result, /bro1/);
+            });
+
+            it('should log error of retried test', () => {
+                test = mkTestStub_({
+                    err: 'some error'
+                });
+
+                emit(RunnerEvents.RETRY, test);
+
+                const result = chalk.stripColor(logger.log.getCall(5).args[0]);
+
+                assert.match(result, /some error/);
+            });
         });
     });
 });


### PR DESCRIPTION
@j0tunn, @sipayRT, @eGavr, @tormozz48, @DudaGod 

Теперь информация об упавших и заретраеных тестах выводится в конце и выглядит так:
<img width="913" alt="2016-09-16 17 36 55" src="https://cloud.githubusercontent.com/assets/8089139/18589692/925a1434-7c34-11e6-9cb2-5b1479070706.png">

