### PR TITLE
Support passing of a runner to a handler of 'RUNNER_START' event

### DIFF
--- a/README.md
+++ b/README.md
@@ -413,7 +413,7 @@ plugins: {
 
 // hermione-my-cool-plugin/index.js
 module.exports = function(hermione, opts) {
-    hermione.on(hermione.events.RUNNER_START, function() {
+    hermione.on(hermione.events.RUNNER_START, function(runner) {
         return setUp(hermione.config, opts.param); // config can be mutated
     });
 
@@ -434,7 +434,7 @@ Property name             | Description
 
 Event                     | Description
 ------------------------- | -------------
-`RUNNER_START`            | Will be triggered before tests execution. If a handler returns a promise, tests will be executed only after promise is resolved.
+`RUNNER_START`            | Will be triggered before tests execution. If a handler returns a promise, tests will be executed only after promise is resolved. Handler accepts an instance of a runner as a first argument. Using this instance you can emit and subscribe to any other available events.
 `RUNNER_END`              | Will be triggered after tests execution. If a handler returns a promise, tests will be executed only after promise is resolved.
 `SESSION_START`           | Will be triggered after browser session initialization. If a handler returns a promise, tests will be executed only after promise is resolved
 `SESSION_END`             | Will be triggered after browser session quit. If a handler returns a promise, tests will be executed only after promise is resolved

--- a/lib/runner/index.js
+++ b/lib/runner/index.js
@@ -39,7 +39,7 @@ module.exports = class MainRunner extends QEmitter {
     run(tests) {
         const anyTest = () => true;
 
-        return this.emitAndWait(RunnerEvents.RUNNER_START)
+        return this.emitAndWait(RunnerEvents.RUNNER_START, this)
             .then(() => this._runTestSession(tests, anyTest))
             .fin(() => {
                 return this.emitAndWait(RunnerEvents.RUNNER_END)

--- a/test/lib/runner/index.js
+++ b/test/lib/runner/index.js
@@ -85,6 +85,16 @@ describe('Runner', () => {
                     .then(() => assert.callOrder(mediator, MochaRunner.prototype.run));
             });
 
+            it('should pass a runner to a RUNNER_START handler', () => {
+                const onRunnerStart = sinon.stub().named('onRunnerStart').returns(q());
+                const runner = new Runner(makeConfigStub());
+
+                runner.on(RunnerEvents.RUNNER_START, onRunnerStart);
+
+                return run_({runner})
+                    .then(() => assert.calledWith(onRunnerStart, runner));
+            });
+
             it('should not run any mocha runner if RUNNER_START handler failed', () => {
                 const onRunnerStart = sinon.stub().named('onRunnerStart').returns(q.reject('some-error'));
                 const runner = new Runner(makeConfigStub());


### PR DESCRIPTION
cc @sipayRT @j0tunn 

Изменение необходимо для того, чтобы подписавшись на событие `RUNNER_START` была возможность из плагина триггерить другие события раннера, например, `TEST_FAIL`.