### PR TITLE
Implement 'test-counter' for 'flat' reporter

### DIFF
--- a/lib/reporters/flat.js
+++ b/lib/reporters/flat.js
@@ -7,6 +7,7 @@ const path = require('path');
 const logger = require('../utils').logger;
 
 const RunnerEvents = require('../constants/runner-events');
+const TestCounter = require('./utils/test-counter');
 
 const ICON_SUCCESS = chalk.green('\u2713');
 const ICON_FAIL = chalk.red('\u2718');
@@ -21,7 +22,8 @@ const getRelativeFilePath = (file) => {
 
 module.exports = class FlatReporter {
     constructor() {
-        this._passed = this._failed = this._pending = this._retries = 0;
+        this._testCounter = new TestCounter();
+
         this._tests = [];
     }
 
@@ -39,19 +41,22 @@ module.exports = class FlatReporter {
     }
 
     _onTestPass(test) {
-        this._passed++;
+        this._testCounter.onTestPass(test);
+
         logger.log(ICON_SUCCESS + this._formatTestInfo(test));
     }
 
     _onTestFail(test) {
-        this._failed++;
+        this._testCounter.onTestFail(test);
+
         logger.log(ICON_FAIL + this._formatTestInfo(test));
 
         this._tests.push(FlatReporter._extendTestInfo(test, {isFailed: true}));
     }
 
     _onRetry(test) {
-        this._retries++;
+        this._testCounter.onTestRetry(test);
+
         logger.log(ICON_RETRY + this._formatTestInfo(test));
         logger.log('Will be retried. Retries left: %s', chalk.yellow(test.retriesLeft));
 
@@ -63,19 +68,20 @@ module.exports = class FlatReporter {
     }
 
     _onTestPending(test) {
-        this._pending++;
+        this._testCounter.onTestPending(test);
+
         logger.log(ICON_WARN + this._formatTestInfo(test));
     }
 
     _onRunnerEnd() {
-        const total = this._passed + this._failed + this._pending;
+        const stats = this._testCounter.getResult();
 
         logger.log('Total: %s Passed: %s Failed: %s Pending: %s Retries: %s',
-            chalk.underline(total),
-            chalk.green(this._passed),
-            chalk.red(this._failed),
-            chalk.cyan(this._pending),
-            chalk.yellow(this._retries)
+            chalk.underline(stats.total),
+            chalk.green(stats.passed),
+            chalk.red(stats.failed),
+            chalk.cyan(stats.pending),
+            chalk.yellow(stats.retries)
         );
 
         FlatReporter._logFailedTestsInfo(this._tests);

--- a/lib/reporters/utils/test-counter.js
+++ b/lib/reporters/utils/test-counter.js
@@ -1,0 +1,53 @@
+'use strict';
+
+const _ = require('lodash');
+
+const STATS = {
+    total: 'total',
+    passed: 'passed',
+    failed: 'failed',
+    pending: 'pending'
+};
+
+module.exports = class TestCounter {
+    constructor() {
+        this._tests = {};
+
+        this._retries = 0;
+    }
+
+    onTestPass(passed) {
+        this._addStat(STATS.passed, passed);
+    }
+
+    onTestFail(failed) {
+        this._addStat(STATS.failed, failed);
+    }
+
+    onTestPending(pending) {
+        this._addStat(STATS.pending, pending);
+    }
+
+    onTestRetry() {
+        this._retries++;
+    }
+
+    _addStat(type, test) {
+        this._tests[test.fullTitle() + ' ' + test.browserId] = type;
+    }
+
+    getResult() {
+        return _(STATS)
+            .mapValues(() => 0)
+            .thru((result) => {
+                return _.reduce(this._tests, (res, stat) => {
+                    res.total++;
+                    res[stat]++;
+
+                    return res;
+                }, result);
+            })
+            .extend({retries: this._retries})
+            .value();
+    }
+};

--- a/test/lib/reporter/utils/test-counter.js
+++ b/test/lib/reporter/utils/test-counter.js
@@ -1,0 +1,75 @@
+'use strict';
+
+const TestCounter = require('../../../../lib/reporters/utils/test-counter');
+
+describe('TestCounter', () => {
+    const stubTest = (opts) => {
+        opts = opts || {};
+
+        return {fullTitle: sinon.stub().returns(opts.name || 'default-name'), browserId: 'bro'};
+    };
+
+    it('should count passed tests', () => {
+        const testCounter = new TestCounter();
+
+        testCounter.onTestPass(stubTest());
+
+        assert.propertyVal(testCounter.getResult(), 'passed', 1);
+    });
+
+    it('should count failed tests', () => {
+        const testCounter = new TestCounter();
+
+        testCounter.onTestFail(stubTest());
+
+        assert.propertyVal(testCounter.getResult(), 'failed', 1);
+    });
+
+    it('should count pending tests', () => {
+        const testCounter = new TestCounter();
+
+        testCounter.onTestPending(stubTest());
+
+        assert.propertyVal(testCounter.getResult(), 'pending', 1);
+    });
+
+    it('should count retried tests', () => {
+        const testCounter = new TestCounter();
+
+        testCounter.onTestRetry();
+
+        assert.propertyVal(testCounter.getResult(), 'retries', 1);
+    });
+
+    it('should count total tests', () => {
+        const testCounter = new TestCounter();
+
+        testCounter.onTestPass(stubTest({name: 'first-test'}));
+        testCounter.onTestFail(stubTest({name: 'second-test'}));
+        testCounter.onTestPending(stubTest({name: 'third-test'}));
+
+        assert.propertyVal(testCounter.getResult(), 'total', 3);
+    });
+
+    it('should not add retries to total', () => {
+        const testCounter = new TestCounter();
+
+        testCounter.onTestRetry();
+        testCounter.onTestPass(stubTest());
+
+        assert.propertyVal(testCounter.getResult(), 'total', 1);
+    });
+
+    it('should support cases when several hanlders were called for the same test', () => {
+        const testCounter = new TestCounter();
+
+        testCounter.onTestPending(stubTest({name: 'some-test'}));
+        testCounter.onTestFail(stubTest({name: 'some-test'}));
+
+        const result = testCounter.getResult();
+
+        assert.propertyVal(result, 'total', 1);
+        assert.propertyVal(result, 'failed', 1);
+        assert.propertyVal(result, 'pending', 0);
+    });
+});


### PR DESCRIPTION
cc @sipayRT @j0tunn 

Изменение необходимо, чтобы учитывать случаи, когда для одного и того же теста во время запуска летит два события, например, сначала `TEST_PENDING`, а затем `TEST_FAIL`.