### PR TITLE
fix logging of errors in 'flat' reporter

### DIFF
--- a/lib/reporters/flat.js
+++ b/lib/reporters/flat.js
@@ -150,7 +150,7 @@ module.exports = class FlatReporter {
             title: test.fullTitle(),
             browser: test.browserId,
             file: getRelativeFilePath(test.file),
-            error: _.get(test, 'err.stack', test.err)
+            error: test.err ? (test.err.stack || test.err.message || test.err) : undefined
         };
     }
 


### PR DESCRIPTION
cc @j0tunn @sipayRT 

Сейчас алгоритм вывода ошибки такой:

Если в тесте есть поле `err`, то пытаемся вывести `err.stack`, иначе просто выводим `err`.

По хорошему надо вот так:

Если в тесте есть `err`, то пытаемся вывести `err.stack` или `err.message`, или `err`, иначе выводим `unknown error`.

Проблема возникла при написании валидатора для скипнутых тестов и интеграции его с `allure`-отчетом.

Если в `allure` прилетает ошибка строкой (из валидатора летела строка), то она не отображается в html-отчете. Чтобы ошибка нормально отобразилось, необходимо наличие поля `message` или `stack`, но если кидать ошибку только с полем `message`, то во `flat`-репортере ошибка отображается как `[Object]`.