### PR TITLE
Remove unnecessary option 'screenshotOnReject' from config

### DIFF
--- a/lib/config/browser-options.js
+++ b/lib/config/browser-options.js
@@ -73,15 +73,6 @@ function buildBrowserOptions(defaultFactory, extra) {
 
         prepareBrowser: options.optionalFunction('prepareBrowser'),
 
-        screenshotOnReject: option({
-            defaultValue: defaultFactory('screenshotOnReject'),
-            validate: (value) => {
-                if (!_.isBoolean(value) && !_.isPlainObject(value)) {
-                    throw new Error('"screenshotOnReject" should be boolean or object');
-                }
-            }
-        }),
-
         screenshotPath: option({
             defaultValue: defaultFactory('screenshotPath'),
             validate: (value) => _.isNull(value) || is('string', 'screenshotPath')(value),

--- a/test/lib/config/browser-options.js
+++ b/test/lib/config/browser-options.js
@@ -298,56 +298,6 @@ describe('config browser-options', () => {
         });
     });
 
-    describe('screenshotOnReject', () => {
-        it('should throw error if screenshotOnReject is not a boolean or object', () => {
-            const readConfig = mkConfig_({
-                browsers: {
-                    b1: mkBrowser_({screenshotOnReject: 'String'})
-                }
-            });
-
-            Config.read.returns(readConfig);
-
-            assert.throws(() => createConfig(), Error, '"screenshotOnReject" should be boolean or object');
-        });
-
-        it('should set screenshotOnReject to all browsers', () => {
-            const screenshotOnReject = true;
-            const readConfig = mkConfig_({
-                screenshotOnReject,
-                browsers: {
-                    b1: mkBrowser_(),
-                    b2: mkBrowser_()
-                }
-            });
-
-            Config.read.returns(readConfig);
-
-            const config = createConfig();
-
-            assert.equal(config.browsers.b1.screenshotOnReject, true);
-            assert.equal(config.browsers.b2.screenshotOnReject, true);
-        });
-
-        it('should override screenshotOnReject option', () => {
-            const screenshotOnReject = true;
-            const readConfig = mkConfig_({
-                screenshotOnReject,
-                browsers: {
-                    b1: mkBrowser_(),
-                    b2: mkBrowser_({screenshotOnReject: false})
-                }
-            });
-
-            Config.read.returns(readConfig);
-
-            const config = createConfig();
-
-            assert.equal(config.browsers.b1.screenshotOnReject, true);
-            assert.equal(config.browsers.b2.screenshotOnReject, false);
-        });
-    });
-
     ['sessionsPerBrowser', 'waitTimeout'].forEach((option) => {
         describe(`${option}`, () => {
             describe(`should throw error if ${option}`, () => {


### PR DESCRIPTION
/cc @sipayRT 

Опция `screenshotOnReject` была добавлена случайно. Изначально предполагалось, что пользователь не должен иметь возможности ее выставлять, кроме как через `allure`-отчет, соответственно и смысла нет в опции `screenshotDir`, так как все скриншоты цепляются к `allure`-отчету.