### PR TITLE
fix: Do not save whole runnable object - decrease memory leaks

### DIFF
--- a/lib/retry-manager/matcher.js
+++ b/lib/retry-manager/matcher.js
@@ -6,13 +6,13 @@ var Matcher = inherit({
     __constructor: function(test, browser) {
         this.browser = browser;
         this.file = test.file;
-        this._test = test;
+        this._fullTitle = test.fullTitle();
     },
 
     test: function(test, browser) {
         return browser === this.browser
             && test.file === this.file
-            && test.fullTitle() === this._test.fullTitle();
+            && test.fullTitle() === this._fullTitle;
     }
 }, {
     create: function(test, browser) {


### PR DESCRIPTION
- matcher will be created for each retry
- test object contains `err` field, which contains huge `screenshot` field