### PR TITLE
fix: fail instead of hang on throws from event handlers

### DIFF
--- a/lib/runner/mocha-runner/mocha-adapter.js
+++ b/lib/runner/mocha-runner/mocha-adapter.js
@@ -11,6 +11,7 @@ const path = require('path');
 const clearRequire = require('clear-require');
 const q = require('q');
 const _ = require('lodash');
+const EventEmitter = require('events').EventEmitter;
 
 // Avoid mochajs warning about possible EventEmitter memory leak
 // https://nodejs.org/docs/latest/api/events.html#events_emitter_setmaxlisteners_n
@@ -46,6 +47,8 @@ module.exports = class MochaAdapter {
         this._injectSkip();
 
         _.extend(global.hermione, {ctx});
+
+        this._errMonitor = new EventEmitter();
     }
 
     applySkip(testSkipper) {
@@ -92,15 +95,35 @@ module.exports = class MochaAdapter {
     }
 
     attachEmitFn(emit) {
+        const _this = this;
+        function monitoredEmit() {
+            try {
+                emit.apply(null, arguments);
+            } catch (e) {
+                _this._errMonitor.emit('err', e);
+                throw e;
+            }
+        }
+
+        this._attachProxyReporter(monitoredEmit);
+        this._passthroughFileEvents(monitoredEmit);
+
+        return this;
+    }
+
+    _attachProxyReporter(emit) {
         const Reporter = _.partial(ProxyReporter, emit, () => this._getBrowser());
         this._mocha.reporter(Reporter);
+    }
 
+    _passthroughFileEvents(emit) {
         const emit_ = (event, file) => emit(event, {
             file,
             hermione: global.hermione,
             browser: this._browserAgent.browserId,
             suite: this.suite
         });
+
         this.suite.on('pre-require', (ctx, file) => emit_(RunnerEvents.BEFORE_FILE_READ, file));
         this.suite.on('post-require', (ctx, file) => emit_(RunnerEvents.AFTER_FILE_READ, file));
 
@@ -108,7 +131,12 @@ module.exports = class MochaAdapter {
     }
 
     run() {
-        return q.Promise(this._mocha.run.bind(this._mocha));
+        const defer = q.defer();
+
+        this._errMonitor.on('err', (err) => defer.reject(err));
+        this._mocha.run((err) => err ? defer.reject(err) : defer.resolve());
+
+        return defer.promise;
     }
 
     _injectSkip() {


### PR DESCRIPTION
Сейчас при исключении из обработчика любого события hermione зависает (т.к. mocha внутри падает и не зовет callback).
Я здесь оборачиваю `emit` т.о. чтобы он никогда не бросал исключений, но при этом валил mocha.run