### PR TITLE
Fix for example in quick start section in Readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -346,15 +346,13 @@ Write your first test.
 ```javascript
 var assert = require('chai').assert;
 
-describe('yandex', function() {
-    it('should find itself', function() {
+describe('github', function() {
+    it('should find hermione', function() {
         return this.browser
-            .url('https://yandex.com')
-            .setValue('.search2__input input', 'yandex')
-            .click('.search2__button button')
-            .getText('.z-entity-card__title')
+            .url('https://github.com/gemini-testing/hermione')
+            .getText('#readme h1')
             .then(function(title) {
-                assert.equal(title, 'Yandex')
+                assert.equal(title, 'Hermione')
             });
     });
 });


### PR DESCRIPTION
Hi there,

love you're doing here, thanks! :)

Found that example in quick start section doesn't work. Actually there's a couple of problems here:

- `.search2__input input -> .search2__input .input__control` (there're two inputs actually, so webdriver fails on trying to pick up the right one)

```
✘ Error: invalid element state: Element is not currently interactable and may not be manipulated
```

- `waitForVisible` (the page needs some time after search request)
- `z-entity-card__title` doesn't seem exist anymore
- changed `com -> ru` to make sure the language is always the same (com can redirect to ru)

**UPD**

Changed test: goes to github page of hermione and find the title