### PR TITLE
feat: Add command "--repeat"

### DIFF
--- a/lib/config/browser-options.js
+++ b/lib/config/browser-options.js
@@ -66,6 +66,8 @@ function buildBrowserOptions(defaultFactory, extra) {
 
         retry: options.nonNegativeInteger('retry'),
 
+        repeat: options.nonNegativeInteger('repeat'),
+
         httpTimeout: options.nonNegativeInteger('httpTimeout'),
 
         sessionRequestTimeout: options.optionalNonNegativeInteger('sessionRequestTimeout'),

--- a/lib/config/defaults.js
+++ b/lib/config/defaults.js
@@ -18,6 +18,7 @@ module.exports = {
     debug: false,
     sessionsPerBrowser: 1,
     retry: 0,
+    repeat: 0,
     mochaOpts: {
         slow: 10000,
         timeout: 60000

--- a/lib/constants/runner-events.js
+++ b/lib/constants/runner-events.js
@@ -30,6 +30,8 @@ const getSyncEvents = () => ({
 
     RETRY: 'retry',
 
+    REPEAT: 'repeat',
+
     INFO: 'info',
     WARNING: 'warning',
     ERROR: 'err'

--- a/lib/repeat-manager/index.js
+++ b/lib/repeat-manager/index.js
@@ -1,0 +1,70 @@
+'use strict';
+
+var _ = require('lodash'),
+    inherit = require('inherit'),
+    EventEmitter = require('events').EventEmitter,
+    RunnerEvents = require('../constants/runner-events'),
+    Matcher = require('./matcher');
+
+var RepeatManager = inherit(EventEmitter, {
+    __constructor: function(config) {
+        this._repeatLeft = _.mapValues(config.browsers, 'repeat');
+        this._matchers = [];
+    },
+
+    handleTestPass: function(data) {
+        const browserId = data.browserId;
+        const repeatLeft = this._repeatLeft[browserId];
+
+        if (!repeatLeft) {
+            this.emit(RunnerEvents.TEST_PASS, data);
+            return;
+        }
+
+        this.emit(RunnerEvents.REPEAT, _.extend(data, {
+            repeatLeft: repeatLeft - 1
+        }));
+
+        this._registerPass(data, browserId);
+    },
+
+    _registerPass: function(runnable, browser) {
+        if (runnable.type === 'test') {
+            this._matchers.push(Matcher.create(runnable, browser));
+        }
+    },
+
+    repeat: function(runFn) {
+        if (_.isEmpty(this._matchers)) {
+            return;
+        }
+
+        this._repeatLeft = _.mapValues(this._repeatLeft, function(repeat) {
+            return repeat && repeat - 1;
+        });
+
+        var matchers = this._matchers,
+            testsToRepeat = this._getTestsToRepeat();
+
+        this._matchers = [];
+
+        return runFn(testsToRepeat, function(test, browser) {
+            return _.any(matchers, function(matcher) {
+                return matcher.test(_.extend(test, {
+                    isRepeat: true
+                }), browser);
+            });
+        });
+    },
+
+    _getTestsToRepeat: function() {
+        return _(this._matchers)
+            .groupBy('browser')
+            .mapValues(function(matchers) {
+                return _(matchers).map('file').uniq().value();
+            })
+            .value();
+    }
+});
+
+module.exports = RepeatManager;

--- a/lib/repeat-manager/matcher.js
+++ b/lib/repeat-manager/matcher.js
@@ -1,0 +1,23 @@
+'use strict';
+
+var inherit = require('inherit');
+
+var Matcher = inherit({
+    __constructor: function(test, browser) {
+        this.browser = browser;
+        this.file = test.file;
+        this._fullTitle = test.fullTitle();
+    },
+
+    test: function(test, browser) {
+        return browser === this.browser
+            && test.file === this.file
+            && test.fullTitle() === this._fullTitle;
+    }
+}, {
+    create: function(test, browser) {
+        return new Matcher(test, browser);
+    }
+});
+
+module.exports = Matcher;

--- a/lib/reporters/base.js
+++ b/lib/reporters/base.js
@@ -28,6 +28,11 @@ module.exports = class BaseReporter {
     }
 
     _onTestPass(test) {
+        if (test.isRepeat) {
+            this._onRepeat(test);
+            return;
+        }
+
         this._testCounter.onTestPass(test);
 
         this._logTestInfo(test, icons.SUCCESS);
@@ -46,6 +51,12 @@ module.exports = class BaseReporter {
         logger.log('Will be retried. Retries left: %s', chalk.yellow(test.retriesLeft));
     }
 
+    _onRepeat(test) {
+        this._testCounter.onTestRepeat(test);
+
+        this._logTestInfo(test, icons.REPEAT);
+    }
+
     _onTestPending(test) {
         this._testCounter.onTestPending(test);
 
@@ -55,12 +66,13 @@ module.exports = class BaseReporter {
     _onRunnerEnd() {
         const stats = this._testCounter.getResult();
 
-        logger.log('Total: %s Passed: %s Failed: %s Pending: %s Retries: %s',
+        logger.log('Total: %s Passed: %s Failed: %s Pending: %s Retries: %s Repeats: %s',
             chalk.underline(stats.total),
             chalk.green(stats.passed),
             chalk.red(stats.failed),
             chalk.cyan(stats.pending),
-            chalk.yellow(stats.retries)
+            chalk.yellow(stats.retries),
+            chalk.yellow(stats.repeats)
         );
     }
 

--- a/lib/reporters/utils/icons.js
+++ b/lib/reporters/utils/icons.js
@@ -6,5 +6,6 @@ module.exports = {
     SUCCESS: chalk.green('\u2713'),
     WARN: chalk.bold.yellow('!'),
     FAIL: chalk.red('\u2718'),
-    RETRY: chalk.yellow('⟳')
+    RETRY: chalk.yellow('⟳'),
+    REPEAT: chalk.green('⟳')
 };

--- a/lib/reporters/utils/test-counter.js
+++ b/lib/reporters/utils/test-counter.js
@@ -14,6 +14,7 @@ module.exports = class TestCounter {
         this._tests = {};
 
         this._retries = 0;
+        this._repeats = 0;
     }
 
     onTestPass(passed) {
@@ -32,6 +33,10 @@ module.exports = class TestCounter {
         this._retries++;
     }
 
+    onTestRepeat() {
+        this._repeats++;
+    }
+
     _addStat(type, test) {
         this._tests[test.fullTitle() + ' ' + test.browserId] = type;
     }
@@ -47,7 +52,10 @@ module.exports = class TestCounter {
                     return res;
                 }, result);
             })
-            .extend({retries: this._retries})
+            .extend({
+                retries: this._retries,
+                repeats: this._repeats
+            })
             .value();
     }
 };

--- a/lib/runner/index.js
+++ b/lib/runner/index.js
@@ -10,6 +10,7 @@ const BrowserPool = require('../browser-pool');
 const RunnerEvents = require('../constants/runner-events');
 const MochaRunner = require('./mocha-runner');
 const RetryManager = require('../retry-manager');
+const RepeatManager = require('../repeat-manager');
 const TestSkipper = require('./test-skipper');
 const logger = require('../utils').logger;
 
@@ -26,11 +27,13 @@ module.exports = class MainRunner extends QEmitter {
         this._testSkipper = TestSkipper.create(this._config);
 
         this._retryMgr = new RetryManager(this._config);
+        this._repeatMgr = new RepeatManager(this._config);
         qUtils.passthroughEvent(this._retryMgr, this, [
             RunnerEvents.TEST_FAIL,
             RunnerEvents.SUITE_FAIL,
             RunnerEvents.ERROR,
-            RunnerEvents.RETRY
+            RunnerEvents.RETRY,
+            RunnerEvents.REPEAT
         ]);
 
         this._pool = new BrowserPool(this._config);
@@ -70,6 +73,9 @@ module.exports = class MainRunner extends QEmitter {
             .value()
             .then(function() {
                 return _this._retryMgr.retry(_this._runTestSession.bind(_this));
+            })
+            .then(function() {
+                return _this._repeatMgr.repeat(_this._runTestSession.bind(_this));
             });
     }
 
@@ -102,6 +108,8 @@ module.exports = class MainRunner extends QEmitter {
         mochaRunner.on(RunnerEvents.TEST_FAIL, (data) => this._retryMgr.handleTestFail(data));
         mochaRunner.on(RunnerEvents.SUITE_FAIL, (data) => this._retryMgr.handleSuiteFail(data));
         mochaRunner.on(RunnerEvents.ERROR, (err, data) => this._retryMgr.handleError(err, data));
+
+        mochaRunner.on(RunnerEvents.TEST_PASS, (data) => this._repeatMgr.handleTestPass(data));
 
         return mochaRunner.run(files, filterFn);
     }


### PR DESCRIPTION
@tormozz48 

Добавил команду --repeat, для прогона тестов на "стабильность"

![](https://api.monosnap.com/rpc/file/download?id=gOmkiE5iv7nnvMU6HsltSINEKxOQ2b)

- [ ] repeats не пробрасывается в stat-reporter
- [ ] emit.REPEAT не отлавливается в формировании отчета, пока костыльнул добавив поле isRepeat
- [ ] подумать над отчетом: например Repeats: 2 / SUCCESS / FAILED - 70% (стабильность)
- [ ] дописать тесты