### PR TITLE
fix: do not run 'before' and 'after' hooks for a skipped suite

### DIFF
--- a/lib/runner/mocha-runner/index.js
+++ b/lib/runner/mocha-runner/index.js
@@ -42,6 +42,7 @@ module.exports = class MochaRunner extends QEmitter {
         this._mochas = this._mochaBuilder.buildAdapters(suitePaths);
 
         validateUniqTitles(this._mochas);
+        this._mochas.forEach((mocha) => mocha.disableHooksInSkippedSuites());
 
         return this;
     }

--- a/lib/runner/mocha-runner/mocha-adapter.js
+++ b/lib/runner/mocha-runner/mocha-adapter.js
@@ -227,10 +227,6 @@ module.exports = class MochaAdapter extends EventEmitter {
     }
 
     _requestBrowser() {
-        if (isSkipped(this.suite)) {
-            return q();
-        }
-
         return this._browserAgent.getBrowser()
             .then((browser) => {
                 this._browser = browser;
@@ -248,11 +244,27 @@ module.exports = class MochaAdapter extends EventEmitter {
     _getBrowser() {
         return this._browser || {id: this._browserAgent.browserId};
     }
+
+    disableHooksInSkippedSuites(suite) {
+        suite = suite || this.suite;
+
+        if (isSkipped(suite)) {
+            disableSuiteHooks(suite);
+        } else {
+            suite.suites.forEach((s) => this.disableHooksInSkippedSuites(s));
+        }
+    }
 };
 
 function isSkipped(suite) {
     return _.every(suite.suites, (s) => isSkipped(s))
         && _.every(suite.tests, 'pending');
+}
+
+function disableSuiteHooks(suite) {
+    suite._beforeAll = [];
+    suite._afterAll = [];
+    suite.suites.forEach((s) => disableSuiteHooks(s));
 }
 
 function markSuiteAsFailed(suite, error) {

--- a/lib/runner/mocha-runner/single-test-mocha-adapter.js
+++ b/lib/runner/mocha-runner/single-test-mocha-adapter.js
@@ -46,4 +46,8 @@ module.exports = class SingleTestMochaAdapter {
     on() {
         return this._mocha.on.apply(this._mocha, arguments);
     }
+
+    disableHooksInSkippedSuites() {
+        return this._mocha.disableHooksInSkippedSuites();
+    }
 };

--- a/test/lib/runner/mocha-runner/single-test-mocha-adapter.js
+++ b/test/lib/runner/mocha-runner/single-test-mocha-adapter.js
@@ -115,4 +115,13 @@ describe('mocha-runner/single-test-mocha-adapter', () => {
 
         assert.deepEqual(singleTestMochaAdapter.on('arg1', 'arg2'), {foo: 'bar'});
     });
+
+    it('should passthrough "disableHooksInSkippedSuites" method from the decorated mocha adapter', () => {
+        const mochaAdapter = mkMochaAdapterStub();
+        const singleTestMochaAdapter = SingleTestMochaAdapter.create(mochaAdapter);
+
+        mochaAdapter.disableHooksInSkippedSuites.returns({foo: 'bar'});
+
+        assert.deepEqual(singleTestMochaAdapter.disableHooksInSkippedSuites(), {foo: 'bar'});
+    });
 });


### PR DESCRIPTION
cc @j0tunn 