### PR TITLE
refactor: correct call of method 'prepare' in the hierarchy of runners

### DIFF
--- a/lib/runner/mocha-runner/index.js
+++ b/lib/runner/mocha-runner/index.js
@@ -6,13 +6,12 @@ const qUtils = require('qemitter/utils');
 const QEmitter = require('qemitter');
 const _ = require('lodash');
 const RunnerEvents = require('../../constants/runner-events');
-const MochaAdapter = require('./mocha-adapter');
 const RetryMochaRunner = require('./retry-mocha-runner');
 const MochaBuilder = require('./mocha-builder');
 
 module.exports = class MochaRunner extends QEmitter {
     static prepare() {
-        MochaAdapter.prepare();
+        MochaBuilder.prepare();
     }
 
     static create(browserId, config, browserPool, testSkipper) {

--- a/lib/runner/mocha-runner/mocha-builder.js
+++ b/lib/runner/mocha-runner/mocha-builder.js
@@ -9,6 +9,10 @@ const MochaAdapter = require('./mocha-adapter');
 const SingleTestMochaAdapter = require('./single-test-mocha-adapter');
 
 module.exports = class MochaBuilder extends EventEmitter {
+    static prepare() {
+        MochaAdapter.prepare();
+    }
+
     static create(browserId, config, browserPool, testSkipper) {
         return new MochaBuilder(browserId, config, browserPool, testSkipper);
     }

--- a/test/lib/runner/mocha-runner/index.js
+++ b/test/lib/runner/mocha-runner/index.js
@@ -4,7 +4,6 @@ const EventEmitter = require('events').EventEmitter;
 const q = require('q');
 const BrowserAgent = require('gemini-core').BrowserAgent;
 const RunnerEvents = require('../../../../lib/constants/runner-events');
-const MochaAdapter = require('../../../../lib/runner/mocha-runner/mocha-adapter');
 const MochaRunner = require('../../../../lib/runner/mocha-runner');
 const RetryMochaRunner = require('../../../../lib/runner/mocha-runner/retry-mocha-runner');
 const TestSkipper = require('../../../../lib/runner/test-skipper');
@@ -28,8 +27,9 @@ describe('mocha-runner', () => {
     const run_ = (suites) => init_(suites).run();
 
     beforeEach(() => {
-        sandbox.stub(MochaAdapter, 'prepare');
         sandbox.stub(RetryMochaRunner.prototype, 'run');
+
+        sandbox.stub(MochaBuilder, 'prepare');
         sandbox.stub(MochaBuilder.prototype, 'buildAdapters').returns([]);
         sandbox.stub(MochaBuilder.prototype, 'buildSingleAdapter');
     });
@@ -69,10 +69,10 @@ describe('mocha-runner', () => {
     });
 
     describe('prepare', () => {
-        it('should prepare mocha adapter', () => {
+        it('should prepare mocha builder', () => {
             MochaRunner.prepare();
 
-            assert.calledOnce(MochaAdapter.prepare);
+            assert.calledOnce(MochaBuilder.prepare);
         });
     });
 

--- a/test/lib/runner/mocha-runner/mocha-builder.js
+++ b/test/lib/runner/mocha-runner/mocha-builder.js
@@ -17,12 +17,21 @@ describe('mocha-runner/mocha-builder', () => {
 
         sandbox.stub(SingleTestMochaAdapter, 'create').returns({tests: []});
 
+        sandbox.stub(MochaAdapter, 'prepare');
         sandbox.stub(MochaAdapter, 'create').callsFake(() => mkMochaAdapterStub_());
         sandbox.stub(MochaAdapter.prototype, 'applySkip').returnsThis();
         sandbox.stub(MochaAdapter.prototype, 'loadFiles');
     });
 
     afterEach(() => sandbox.restore());
+
+    describe('prepare', () => {
+        it('should prepare mocha adapter', () => {
+            MochaBuilder.prepare();
+
+            assert.calledOnce(MochaAdapter.prepare);
+        });
+    });
 
     describe('buildAdapters', () => {
         const buildAdapters_ = (paths) => MochaBuilder.create('bro', {}).buildAdapters(paths);


### PR DESCRIPTION
@j0tunn JFYI

После того, как мы добавили новый уровень абстракции `MochaBuilder`, я забыл, что надо метод `prepare` прокидывать по иерархии `runner`-ов.