### PR TITLE
fix: Replace mocha timeouts with promise timeouts

### DIFF
--- a/lib/runner/mocha-runner/mocha-adapter.js
+++ b/lib/runner/mocha-runner/mocha-adapter.js
@@ -46,6 +46,7 @@ module.exports = class MochaAdapter extends EventEmitter {
 
         this.tests = [];
 
+        this._replaceTimeouts();
         this._injectBeforeHookErrorHandling();
         this._injectBeforeEachHookErrorHandling();
         this._injectBrowser();
@@ -160,6 +161,22 @@ module.exports = class MochaAdapter extends EventEmitter {
                 };
             })
         );
+    }
+
+    _replaceTimeouts() {
+        this._addEventHandler(['beforeAll', 'beforeEach', 'test', 'afterEach', 'afterAll'], (runnable) => {
+            if (!runnable.enableTimeouts()) {
+                return;
+            }
+
+            const baseFn = runnable.fn;
+            const timeout = runnable.timeout() || Infinity;
+
+            runnable.enableTimeouts(false);
+            runnable.fn = function() {
+                return q(baseFn).apply(this, arguments).timeout(timeout);
+            };
+        });
     }
 
     _injectBeforeHookErrorHandling() {

--- a/test/lib/_mocha/runnable.js
+++ b/test/lib/_mocha/runnable.js
@@ -21,4 +21,21 @@ module.exports = class Runnable {
     run() {
         return this.fn();
     }
+
+    enableTimeouts(val) {
+        if (val === undefined) {
+            return this._enableTimeouts;
+        }
+
+        this._enableTimeouts = val;
+    }
+
+    timeout(val) {
+        if (val === undefined) {
+            return this._timeout;
+        }
+
+        this.enableTimeouts(true);
+        this._timeout = val;
+    }
 };

--- a/test/lib/runner/mocha-runner/mocha-adapter.js
+++ b/test/lib/runner/mocha-runner/mocha-adapter.js
@@ -297,6 +297,52 @@ describe('mocha-runner/mocha-adapter', () => {
         });
     });
 
+    describe('timeouts', () => {
+        beforeEach(() => {
+            mkMochaAdapter_();
+        });
+
+        it('should disable mocha timeouts', () => {
+            const test = new MochaStub.Test();
+            test.enableTimeouts(true);
+
+            MochaStub.lastInstance.updateSuiteTree((suite) => suite.addTest(test));
+
+            assert.isFalse(test.enableTimeouts());
+        });
+
+        it('should set promise timeout', () => {
+            const test = new MochaStub.Test(null, {
+                fn: () => q.delay(100)
+            });
+            test.timeout(50);
+            MochaStub.lastInstance.updateSuiteTree((suite) => suite.addTest(test));
+
+            return assert.isRejected(test.run(), /Timed out/);
+        });
+
+        it('should not fail test if timeout not exceeded', () => {
+            const test = new MochaStub.Test(null, {
+                fn: () => q.delay(50)
+            });
+            test.timeout(100);
+            MochaStub.lastInstance.updateSuiteTree((suite) => suite.addTest(test));
+
+            return assert.isFulfilled(test.run());
+        });
+
+        it('should not set timeout if it is disabled', () => {
+            const test = new MochaStub.Test(null, {
+                fn: () => q.delay(100)
+            });
+            test.timeout(50);
+            test.enableTimeouts(false);
+            MochaStub.lastInstance.updateSuiteTree((suite) => suite.addTest(test));
+
+            return assert.isFulfilled(test.run());
+        });
+    });
+
     describe('inject execution context', () => {
         let browser;
         let mochaAdapter;


### PR DESCRIPTION
Promise timeout errors will be correctly handled by our wrappers.

Instead of mocha error `timeout of 60000ms exceeded. Ensure the done() callback is being called in this test` there will be q error `Timed out after 60000 ms`