### PR TITLE
fix: 'hermione.only.in' functionality

### DIFF
--- a/lib/runner/mocha-runner/proxy-reporter.js
+++ b/lib/runner/mocha-runner/proxy-reporter.js
@@ -31,9 +31,19 @@ module.exports = inherit(mocha.reporters.Base, {
         this._translateEvent(runner, MochaEvents.TEST_BEGIN, RunnerEvents.TEST_BEGIN);
         this._translateEvent(runner, MochaEvents.TEST_END, RunnerEvents.TEST_END);
         this._translateEvent(runner, MochaEvents.TEST_PASS, RunnerEvents.TEST_PASS);
-        this._translateEvent(runner, MochaEvents.TEST_PENDING, RunnerEvents.TEST_PENDING);
 
+        this._translatePending(runner);
         this._translateFail(runner);
+    },
+
+    _translatePending: function(runner) {
+        const isSilentSkip = (runnable) => runnable && (runnable.silentSkip || isSilentSkip(runnable.parent));
+
+        runner.on(MochaEvents.TEST_PENDING, (test) => {
+            if (!isSilentSkip(test)) {
+                this._emit(RunnerEvents.TEST_PENDING, test);
+            }
+        });
     },
 
     _translateFail: function(runner) {

--- a/lib/runner/mocha-runner/skip/index.js
+++ b/lib/runner/mocha-runner/skip/index.js
@@ -14,18 +14,12 @@ module.exports = class Skip {
         }
 
         if (this.silent) {
-            this._rmFromTree(entity);
+            _.extend(entity, {pending: true, silentSkip: true});
         } else {
             _.extend(entity, {pending: true, skipReason: this.comment});
         }
 
         this._resetInfo();
-    }
-
-    _rmFromTree(entity) {
-        entity.type === 'test'
-            ? entity.parent.tests.pop()
-            : entity.parent.suites.pop();
     }
 
     _resetInfo() {

--- a/test/lib/runner/mocha-runner/proxy-reporter.js
+++ b/test/lib/runner/mocha-runner/proxy-reporter.js
@@ -44,6 +44,28 @@ describe('mocha-runner/proxy-reporter', () => {
     testTranslateEvent_('pass', 'passTest');
     testTranslateEvent_('pending', 'pendingTest');
 
+    describe('"pending" event', () => {
+        beforeEach(() => createReporter_());
+
+        it('should not translate "pending" event if an entity was skipped silently', () => {
+            runner.emit('pending', {silentSkip: true});
+
+            assert.notCalled(emit);
+        });
+
+        it('should not translate "pending" event if a parent of an entity was skipped silently', () => {
+            runner.emit('pending', {parent: {parent: {silentSkip: true}}});
+
+            assert.notCalled(emit);
+        });
+
+        it('should translate "pending" event if an entity was not skipped silently', () => {
+            runner.emit('pending', {foo: 'bar'});
+
+            assert.calledWithMatch(emit, 'pending', {foo: 'bar'});
+        });
+    });
+
     it('should translate `fail` event from test to `failTest`', () => {
         createReporter_();
 

--- a/test/lib/runner/mocha-runner/proxy-reporter.js
+++ b/test/lib/runner/mocha-runner/proxy-reporter.js
@@ -66,64 +66,60 @@ describe('mocha-runner/proxy-reporter', () => {
         });
     });
 
-    it('should translate `fail` event from test to `failTest`', () => {
-        createReporter_();
+    describe('"fail" event', () => {
+        beforeEach(() => createReporter_());
 
-        runner.emit('fail', {type: 'test'}, {message: 'foo'});
+        it('should translate `fail` event from test to `failTest`', () => {
+            runner.emit('fail', {type: 'test'}, {message: 'foo'});
 
-        assert.calledWithMatch(emit, 'failTest', {
-            err: {message: 'foo'}
+            assert.calledWithMatch(emit, 'failTest', {
+                err: {message: 'foo'}
+            });
         });
-    });
 
-    it('should translate `fail` event from after* hook to `err`', () => {
-        createReporter_();
-
-        const hook = {
-            type: 'hook',
-            title: '"after each" hook for "some test"',
-            originalTitle: '"after each" hook',
-            ctx: {
-                currentTest: {
-                    title: 'some test'
+        it('should translate `fail` event from after* hook to `err`', () => {
+            const hook = {
+                type: 'hook',
+                title: '"after each" hook for "some test"',
+                originalTitle: '"after each" hook',
+                ctx: {
+                    currentTest: {
+                        title: 'some test'
+                    }
                 }
-            }
-        };
+            };
 
-        runner.emit('fail', hook, {message: 'foo'});
+            runner.emit('fail', hook, {message: 'foo'});
 
-        assert.calledWithMatch(emit, 'err',
-            {message: 'foo'},
-            hook
-        );
-    });
+            assert.calledWithMatch(emit, 'err',
+                {message: 'foo'},
+                hook
+            );
+        });
 
-    it('should translate `fail` event from hook without currentTest to `err`', () => {
-        createReporter_();
+        it('should translate `fail` event from hook without currentTest to `err`', () => {
+            const hook = {
+                type: 'hook',
+                title: '"before All" hook',
+                ctx: {}
+            };
 
-        const hook = {
-            type: 'hook',
-            title: '"before All" hook',
-            ctx: {}
-        };
+            runner.emit('fail', hook, {message: 'foo'});
 
-        runner.emit('fail', hook, {message: 'foo'});
+            assert.calledWithMatch(emit, 'err',
+                {message: 'foo'},
+                hook
+            );
+        });
 
-        assert.calledWithMatch(emit, 'err',
-            {message: 'foo'},
-            hook
-        );
-    });
+        it('should translate `fail` event from other source to `err`', () => {
+            runner.emit('fail', {title: 'some-title'}, {message: 'foo'});
 
-    it('should translate `fail` event from other source to `err`', () => {
-        createReporter_();
-
-        runner.emit('fail', {title: 'some-title'}, {message: 'foo'});
-
-        assert.calledWithMatch(emit, 'err',
-            {message: 'foo'},
-            {title: 'some-title'}
-        );
+            assert.calledWithMatch(emit, 'err',
+                {message: 'foo'},
+                {title: 'some-title'}
+            );
+        });
     });
 
     it('should translate test data from mocha', () => {

--- a/test/lib/runner/mocha-runner/skip/index.js
+++ b/test/lib/runner/mocha-runner/skip/index.js
@@ -27,102 +27,73 @@ describe('Skip', () => {
     });
 
     describe('handleEntity', () => {
-        it('should extend test data with additional info', () => {
-            const test = mkTest();
-            skip.shouldSkip = true;
-            skip.silent = false;
+        describe('loud skip', () => {
+            beforeEach(() => skip.silent = false);
 
-            skip.handleEntity(test);
-
-            assert.propertyVal(test, 'pending', true);
-            assert.property(test, 'skipReason');
-        });
-
-        it('should not extend test data if browser does not match', () => {
-            const test = mkTest();
-            skip.shouldSkip = false;
-            skip.silent = false;
-
-            skip.handleEntity(test);
-
-            assert.notProperty(test, 'pending');
-            assert.notProperty(test, 'skipReason');
-        });
-
-        it('should not mark silently skipped test as skipped', () => {
-            const test = mkTest();
-            skip.shouldSkip = true;
-            skip.silent = true;
-
-            skip.handleEntity(test);
-
-            assert.notProperty(test, 'pending');
-            assert.notProperty(test, 'skipReason');
-        });
-
-        it('should reset skip data after test will be skipped loudly', () => {
-            const test = mkTest();
-            skip.shouldSkip = true;
-            skip.silent = false;
-
-            skip.handleEntity(test);
-
-            assert.equal(skip.comment, '');
-            assert.equal(skip.shouldSkip, false);
-            assert.equal(skip.silent, false);
-        });
-
-        it('should reset skip data after test will be skipped silently', () => {
-            const test = mkTest();
-            skip.shouldSkip = true;
-            skip.silent = true;
-
-            skip.handleEntity(test);
-
-            assert.equal(skip.comment, '');
-            assert.equal(skip.shouldSkip, false);
-            assert.equal(skip.silent, false);
-        });
-
-        describe('silent flag', () => {
-            it('should remove silently skipped test from the end of parent tests', () => {
-                const test = _.set({type: 'test'}, 'parent.tests', ['test1', 'test2']);
+            it('should extend test data with additional info if an entity should be skipped', () => {
+                const test = mkTest();
                 skip.shouldSkip = true;
-                skip.silent = true;
 
                 skip.handleEntity(test);
 
-                assert.deepEqual(test.parent.tests, ['test1']);
+                assert.propertyVal(test, 'pending', true);
+                assert.property(test, 'skipReason');
             });
 
-            it('should not remove skipped test without silent flag from parent', () => {
-                const test = _.set({type: 'test'}, 'parent.tests', ['test1']);
-                skip.shouldSkip = true;
-                skip.silent = false;
+            it('should not extend test data if an entity should not be skipped', () => {
+                const test = mkTest();
+                skip.shouldSkip = false;
 
                 skip.handleEntity(test);
 
-                assert.deepEqual(test.parent.tests, ['test1']);
+                assert.notProperty(test, 'pending');
+                assert.notProperty(test, 'skipReason');
             });
 
-            it('should remove silently skipped suite from the end of parent suites', () => {
-                const suite = _.set({}, 'parent.suites', ['suite1', 'suite2']);
+            it('should reset skip data after skip', () => {
+                const test = mkTest();
                 skip.shouldSkip = true;
-                skip.silent = true;
 
-                skip.handleEntity(suite);
+                skip.handleEntity(test);
 
-                assert.deepEqual(suite.parent.suites, ['suite1']);
+                assert.equal(skip.comment, '');
+                assert.equal(skip.shouldSkip, false);
+                assert.equal(skip.silent, false);
+            });
+        });
+
+        describe('silent skip', () => {
+            beforeEach(() => skip.silent = true);
+
+            it('should extend test data with additional info if an entity should be skipped', () => {
+                const test = mkTest();
+                skip.shouldSkip = true;
+
+                skip.handleEntity(test);
+
+                assert.propertyVal(test, 'pending', true);
+                assert.propertyVal(test, 'silentSkip', true);
             });
 
-            it('should not remove skipped suite without silent flag from parent', () => {
-                const suite = _.set({type: 'test'}, 'parent.suites', ['suite1']);
+            it('should not extend test data if an entity should not be skipped', () => {
+                const test = mkTest();
+                skip.shouldSkip = false;
+
+                skip.handleEntity(test);
+
+                assert.notProperty(test, 'pending');
+                assert.notProperty(test, 'skipReason');
+            });
+
+            it('should reset skip data after skip', () => {
+                const test = mkTest();
                 skip.shouldSkip = true;
-                skip.silent = false;
 
-                skip.handleEntity(suite);
+                skip.handleEntity(test);
 
-                assert.deepEqual(suite.parent.suites, ['suite1']);
+                assert.equal(skip.comment, '');
+                assert.equal(skip.shouldSkip, false);
+                assert.equal(skip.silent, false);
             });
         });
     });


### PR DESCRIPTION
cc @j0tunn 

Grand Failure после https://github.com/gemini-testing/hermione/pull/146

```js
// Имеем два браузера 'bro1' и 'bro2' в конфиге

describe('suite', () => {
    it('test1', () => {
        // ...
    });

    hermione.only.in('bro2')
    it('test2', () => {
        // ...
    });
});
```

В таком случае `test1` не запускается в `bro1`, хотя должен.

-------------

Проблема возникла в новой схеме создания `moch`, которые содержат по одному тесту. Там слегка конфликтует логика удаления тестов при `silent` skip-e и логика удаления тестов в `attachTestsFilter`.
Идея фикса заключается в том, чтобы при `silent` skip-е ничего не удалять, а разруливать этот тип skip-ов на уровне `proxy-reporter`-а; кажется, что он прям для этого идеально подходит.