### PR TITLE
fix: load plugins early

### DIFF
--- a/lib/hermione.js
+++ b/lib/hermione.js
@@ -40,8 +40,9 @@ module.exports = class Hermione extends QEmitter {
 
         validateUnknownBrowsers(options.browsers, _.keys(this._config.browsers));
 
-        const runner = Runner.create(this._config);
+        this._loadPlugins();
 
+        const runner = Runner.create(this._config);
         runner.on(RunnerEvents.TEST_FAIL, () => this._fail());
         runner.on(RunnerEvents.ERROR, () => this._fail());
 
@@ -51,7 +52,6 @@ module.exports = class Hermione extends QEmitter {
         qUtils.passthroughEventAsync(runner, this, _.values(RunnerEvents.getAsync()));
         qUtils.passthroughEventAsync(signalHandler, this, RunnerEvents.EXIT);
 
-        this._loadPlugins();
         _.extend(this._config.system.mochaOpts, {grep: options.grep});
 
         return sets.reveal(this._config.sets, options)
@@ -60,10 +60,10 @@ module.exports = class Hermione extends QEmitter {
     }
 
     readTests(testPaths, browsers) {
-        const runner = Runner.create(this._config);
-
-        qUtils.passthroughEvent(runner, this, _.values(RunnerEvents.getSync()));
         this._loadPlugins();
+
+        const runner = Runner.create(this._config);
+        qUtils.passthroughEvent(runner, this, _.values(RunnerEvents.getSync()));
 
         return sets.reveal(this._config.sets, {paths: testPaths, browsers})
             .then((tests) => runner.buildSuiteTree(tests));

--- a/test/lib/hermione.js
+++ b/test/lib/hermione.js
@@ -115,6 +115,13 @@ describe('hermione', () => {
                 return runHermione()
                     .then(() => assert.calledWith(pluginsLoader.load, sinon.match.any, sinon.match.any, 'hermione-'));
             });
+
+            it('should load plugins before creating any runner', () => {
+                sandbox.spy(Runner, 'create');
+
+                return runHermione()
+                    .then(() => assert.callOrder(pluginsLoader.load, Runner.create));
+            });
         });
 
         describe('sets revealing', () => {


### PR DESCRIPTION
Необходимо для того, чтобы можно было переопределить какие-то методы у hermione до того как они начнут использоваться. Например обернуть `emitAndWait`