### PR TITLE
Fix: do not hang on errors in config.prepareBrowser

### DIFF
--- a/lib/browser.js
+++ b/lib/browser.js
@@ -88,10 +88,6 @@ module.exports = class Browser {
         this._addExtendOptionsMethod(session);
         this._decorateUrlMethod(session);
 
-        if (this._config.prepareBrowser) {
-            this._config.prepareBrowser(session);
-        }
-
         return session;
     }
 

--- a/lib/worker/browser-pool.js
+++ b/lib/worker/browser-pool.js
@@ -3,6 +3,7 @@
 const _ = require('lodash');
 const Browser = require('../browser');
 const RunnerEvents = require('./constants/runner-events');
+const logger = require('../utils').logger;
 
 module.exports = class BrowserPool {
     static create(config, emitter) {
@@ -25,12 +26,25 @@ module.exports = class BrowserPool {
             browser = Browser.create(this._config, browserId);
             this._browsers[browserId].push(browser);
 
-            this._emitter.emit(RunnerEvents.NEW_BROWSER, browser.publicAPI, {browserId});
+            try {
+                this._initBrowser(browser);
+            } catch (e) {
+                logger.warn(`WARN: couldn't intialize browser ${browserId}\n`, e.stack);
+            }
         }
 
         browser.sessionId = sessionId;
 
         return browser;
+    }
+
+    _initBrowser(browser) {
+        const config = this._config.forBrowser(browser.id);
+        if (config.prepareBrowser) {
+            config.prepareBrowser(browser.publicAPI);
+        }
+
+        this._emitter.emit(RunnerEvents.NEW_BROWSER, browser.publicAPI, {browserId: browser.id});
     }
 
     freeBrowser(browser) {

--- a/lib/worker/runner/mocha-runner/mocha-adapter.js
+++ b/lib/worker/runner/mocha-runner/mocha-adapter.js
@@ -120,7 +120,7 @@ module.exports = class MochaAdapter extends EventEmitter {
     }
 
     _freeBrowser() {
-        this._browserAgent.freeBrowser(this._browser);
+        this._browser && this._browserAgent.freeBrowser(this._browser);
     }
 
     _injectSkip() {
@@ -240,7 +240,7 @@ module.exports = class MochaAdapter extends EventEmitter {
         this._errMonitor.on('err', (err) => defer.reject(err));
 
         this._mocha.run(() => {
-            const meta = this._browser.meta;
+            const meta = this._browser && this._browser.meta;
 
             return this._fail ? defer.reject(_.extend(this._fail, {meta})) : defer.resolve({meta});
         });

--- a/test/lib/browser.js
+++ b/test/lib/browser.js
@@ -368,11 +368,5 @@ describe('Browser', () => {
                 .then((browser) => browser.quit())
                 .then(() => assert.called(logger.warn));
         });
-
-        it('should handle an error from prepareBrowser', () => {
-            const prepareBrowser = sandbox.stub().throws();
-
-            assert.throws(() => mkBrowser_({prepareBrowser}));
-        });
     });
 });


### PR DESCRIPTION
- do not call `config.prepareBrowser` in master process
- call `config.prepareBrowser` in browser pool after Browser intialization instead of calling it in Browser constructor
- wrap `config.prepareBrowser` call (and NEW_BROWSER event emitting) with `try-catch` block