### PR TITLE
feat: load plugins synchronously in constructor, add async INIT event

### DIFF
--- a/README.md
+++ b/README.md
@@ -600,6 +600,7 @@ Property name             | Description
 
 Event                     | Description
 ------------------------- | -------------
+`INIT`                    | Will be triggered before any job start (`run` or `readTests`). If handler returns a promise then job will start only after the promise will be resolved. Emitted only once no matter how many times job will be performed.
 `BEFORE_FILE_READ`        | Will be triggered on test files parsing before reading the file. The handler accepts data object with `file`, `browser` (browser id string), `hermione` (helper which will be available in test file) and `suite` (collection of tests in a file; provides the ability to subscribe on `test` and `suite` events) fields.
 `AFTER_FILE_READ`         | Will be triggered on test files parsing right after reading the file. The handler accepts data object with `file`, `browser` (browser id string), `hermione` (helper which will be available in test file) and `suite` (collection of tests in a file; provides the ability to subscribe on `test` and `suite` events) fields.
 `RUNNER_START`            | Will be triggered before test execution. If a handler returns a promise, tests will be executed only after the promise is resolved. The handler accepts an instance of a runner as the first argument. You can use this instance to emit and subscribe to any other available events.
@@ -788,7 +789,7 @@ hermione.readTests(testPaths, browsers, options).done();
 * **testPaths** (required) `String[]` – Paths to tests relative to `process.cwd`.
 * **browsers** (optional) `String[]` – Read tests only for the specified browsers.
 * **options** (optional) `Object`:
-  * **loadPlugins** (optional) `Boolean` – flag which enables/disables loading of plugins before reading tests; default is `true`.
+  * **silent** (optional) `Boolean` – flag to disable events emitting while reading tests; default is `false`.
 
 ### isFailed
 

--- a/lib/base-hermione.js
+++ b/lib/base-hermione.js
@@ -3,7 +3,6 @@
 const _ = require('lodash');
 const AsyncEmitter = require('gemini-core').events.AsyncEmitter;
 const pluginsLoader = require('plugins-loader');
-const q = require('q');
 
 const Config = require('./config');
 const RunnerEvents = require('./constants/runner-events');
@@ -20,6 +19,7 @@ module.exports = class BaseHermione extends AsyncEmitter {
         super();
 
         this._config = Config.create(configPath);
+        this._loadPlugins();
     }
 
     get config() {
@@ -35,6 +35,6 @@ module.exports = class BaseHermione extends AsyncEmitter {
     }
 
     _loadPlugins() {
-        return q.all(pluginsLoader.load(this, this.config.plugins, PREFIX));
+        pluginsLoader.load(this, this.config.plugins, PREFIX);
     }
 };

--- a/lib/constants/runner-events.js
+++ b/lib/constants/runner-events.js
@@ -3,6 +3,8 @@
 const _ = require('lodash');
 
 const getAsyncEvents = () => ({
+    INIT: 'init',
+
     RUNNER_START: 'startRunner',
     RUNNER_END: 'endRunner',
 

--- a/lib/hermione.js
+++ b/lib/hermione.js
@@ -18,9 +18,9 @@ module.exports = class Hermione extends BaseHermione {
         this._failed = false;
     }
 
-    init() {
-        return this._loadPlugins()
-            .then(() => this);
+    _init() {
+        this._init = () => q(); // init only once
+        return this.emitAndWait(RunnerEvents.INIT);
     }
 
     run(testPaths, options) {
@@ -40,24 +40,22 @@ module.exports = class Hermione extends BaseHermione {
 
         _.extend(this._config.system.mochaOpts, {grep: options.grep});
 
-        return this._loadPlugins()
+        return this._init()
             .then(() => sets.reveal(this._config.sets, {paths: testPaths, browsers: options.browsers, sets: options.sets}))
             .then((testFiles) => runner.run(testFiles))
             .then(() => !this.isFailed());
     }
 
-    readTests(testPaths, browsers, options) {
-        options = _.defaults(options || {}, {loadPlugins: true});
-
+    readTests(testPaths, browsers, options = {}) {
         const runner = Runner.create(this._config);
 
-        let load = q();
-        if (options.loadPlugins) {
+        let init = q();
+        if (!options.silent) {
             eventsUtils.passthroughEvent(runner, this, _.values(RunnerEvents.getSync()));
-            load = this._loadPlugins();
+            init = this._init();
         }
 
-        return load
+        return init
             .then(() => sets.reveal(this._config.sets, {paths: testPaths, browsers}))
             .then((testFiles) => runner.buildSuiteTree(testFiles));
     }

--- a/lib/worker/hermione.js
+++ b/lib/worker/hermione.js
@@ -17,8 +17,7 @@ module.exports = class Hermione extends BaseHermione {
             RunnerEvents.NEW_BROWSER
         ]);
 
-        return this._loadPlugins()
-            .then(() => this._runner.init(testFiles));
+        this._runner.init(testFiles);
     }
 
     runTest(fullTitle, options) {

--- a/lib/worker/index.js
+++ b/lib/worker/index.js
@@ -1,17 +1,17 @@
 'use strict';
 
-const q = require('q');
 const Hermione = require('./hermione');
 
 let hermione;
 
 exports.init = function(testFiles, configPath, cb) {
-    hermione = Hermione.create(configPath);
-
-    q()
-        .then(() => hermione.init(testFiles))
-        .then(() => cb())
-        .catch((err) => cb(err));
+    try {
+        hermione = Hermione.create(configPath);
+        hermione.init(testFiles);
+        cb();
+    } catch (err) {
+        cb(err);
+    }
 };
 
 exports.syncConfig = (config, cb) => {

--- a/test/lib/cli/index.js
+++ b/test/lib/cli/index.js
@@ -5,7 +5,6 @@ const _ = require('lodash');
 const q = require('q');
 const hermioneCli = require('../../../lib/cli');
 const info = require('../../../lib/cli/info');
-const Config = require('../../../lib/config');
 const defaults = require('../../../lib/config/defaults');
 const Hermione = require('../../../lib/hermione');
 const logger = require('../../../lib/utils').logger;
@@ -23,9 +22,7 @@ describe('cli', () => {
     };
 
     beforeEach(() => {
-        sandbox.stub(Config, 'create');
-
-        sandbox.spy(Hermione, 'create');
+        sandbox.stub(Hermione, 'create').returns(Object.create(Hermione.prototype));
         sandbox.stub(Hermione.prototype, 'run').returns(q(true));
 
         sandbox.stub(logger, 'log');


### PR DESCRIPTION
- унес подключение плагинов в конструктор `hermione`
- добавил асинхронное событие `INIT`
- переименовал в `readTests` опцию `loadPlugins` в `silent`, т.к. плагины подключаются в конструкторе, просто при выставленной опции `silent` не летят события от раннера