### PR TITLE
feat(config): introduce shouldRerty config option

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,6 +36,7 @@ Hermione is a utility for integration testing of web pages using [WebdriverIO](h
   - [sessionsPerBrowser](#sessionsperbrowser)
   - [testsPerSession](#testspersession)
   - [retry](#retry)
+  - [shouldRetry](#shouldRetry)
   - [calibrate](#calibrate)
   - [meta](#meta)
   - [windowSize](#windowsize)
@@ -463,6 +464,7 @@ Option name               | Description
 `sessionsPerBrowser`      | Number of sessions which are run simultaneously. Default value is `1`.
 `testsPerSession`         | Maximum amount of tests (`it`s) to run in each web driver session.
 `retry`                   | How many times a test should be rerun. Default value is `0`.
+`shouldRetry`             | Function that determines whether to make a retry. By default returns `true `if retry attempts are available otherwise returns `false`. 
 `calibrate`               | Allows to correctly capture the image. Default value is `false`.
 `screenshotPath`          | Directory to save screenshots by Webdriverio. Default value is `null`.
 `meta`                    | Additional data that can be obtained via .getMeta() method
@@ -495,6 +497,14 @@ By default is `Infinity` (no limit, all tests will be run in the same session). 
 
 ### retry
 How many times a test should be retried if it fails. Global value for all browsers. Default value is `0`.
+
+## shouldRetry
+Function that determines whether to make a retry. Must return boolean value. By default returns `true` if retry attempts are available otherwise returns `false`.
+Argument of this function is object with fields:
+  * `retriesLeft {Number}` — number of available retries
+  * `ctx` — in case of test `TEST_FAIL` it would be bound data, in case of `ERROR` it would be link to `Runnable`
+  * `[error]` — error type (available only in case of ERROR)
+  
 
 ### calibrate
 Does this browser need to perform the calibration procedure. This procedure allows to correctly capture the image in case the particular WebDriver implementation captures browser UI along with web page. Default value is `false`.

--- a/lib/runner/mocha-runner/retry-mocha-runner.js
+++ b/lib/runner/mocha-runner/retry-mocha-runner.js
@@ -25,7 +25,7 @@ module.exports = class RetryMochaRunner extends EventEmitter {
     }
 
     _handleFail(event, failed) {
-        if (!this._hasRetriesLeft()) {
+        if (!this._shouldRetry(failed)) {
             this.emit(event, failed);
             return;
         }
@@ -38,7 +38,7 @@ module.exports = class RetryMochaRunner extends EventEmitter {
     }
 
     _handleError(event, err, failed) {
-        if (!failed || !failed.parent || !this._hasRetriesLeft()) {
+        if (!failed || !failed.parent || !this._shouldRetry(failed, err)) {
             this.emit(event, err, failed);
             return;
         }
@@ -47,19 +47,19 @@ module.exports = class RetryMochaRunner extends EventEmitter {
     }
 
     _emitRetry(failed) {
-        this._shouldRetry = true;
+        this._retryFlag = true;
         this.emit(RunnerEvents.RETRY, _.extend(failed, {retriesLeft: this._retriesLeft - 1}));
     }
 
     run(workers) {
-        this._shouldRetry = false;
+        this._retryFlag = false;
 
         return this._mocha.run(workers)
             .then(() => this._retry(workers));
     }
 
     _retry(workers) {
-        if (!this._shouldRetry) {
+        if (!this._retryFlag) {
             return;
         }
 
@@ -68,7 +68,15 @@ module.exports = class RetryMochaRunner extends EventEmitter {
         return this.run(workers);
     }
 
-    _hasRetriesLeft() {
+    _shouldRetry(data, error) {
+        if (typeof this._config.shouldRetry === 'function') {
+            return Boolean(this._config.shouldRetry({
+                ctx: data,
+                retriesLeft: this._retriesLeft,
+                error
+            }));
+        }
+
         return this._retriesLeft > 0;
     }
 


### PR DESCRIPTION
Config should provide to users option to set custom rule whether test retry
needed or not. 

Relates to: 
* FEI-8660
* https://github.com/gemini-testing/retry-limiter/pull/6