### PR TITLE
Cover hermione with tests

### DIFF
--- a/test/lib/hermione.js
+++ b/test/lib/hermione.js
@@ -2,10 +2,11 @@
 
 const _ = require('lodash');
 const eventsUtils = require('gemini-core').events.utils;
-const AsyncEmitter = require('gemini-core').events.AsyncEmitter;
-const EventEmitter = require('events').EventEmitter;
+const {AsyncEmitter} = require('gemini-core').events;
+const {EventEmitter} = require('events');
 const pluginsLoader = require('plugins-loader');
 const q = require('q');
+const proxyquire = require('proxyquire').noCallThru();
 
 const Config = require('lib/config');
 const RuntimeConfig = require('lib/config/runtime-config');
@@ -15,7 +16,7 @@ const signalHandler = require('lib/signal-handler');
 const Runner = require('lib/runner');
 const sets = require('lib/sets');
 const logger = require('lib/utils/logger');
-const makeConfigStub = require('../utils').makeConfigStub;
+const {makeConfigStub} = require('../utils');
 
 describe('hermione', () => {
     const sandbox = sinon.sandbox.create();
@@ -156,6 +157,73 @@ describe('hermione', () => {
 
                 return hermione.run()
                     .then(() => assert.callOrder(afterInit, Runner.prototype.run));
+            });
+
+            it('should send INIT event only once', () => {
+                const onInit = sinon.spy();
+                const hermione = Hermione.create()
+                    .on(RunnerEvents.INIT, onInit);
+
+                return hermione.run().then(hermione.run()).then(() => {
+                    assert.calledOnce(onInit);
+                });
+            });
+        });
+
+        describe('reporters', () => {
+            let HermioneQuire;
+            let attachRunner;
+            let runner;
+
+            const createReporter = () => {
+                return function Reporter() {
+                    this.attachRunner = attachRunner;
+                };
+            };
+
+            beforeEach(() => {
+                HermioneQuire = proxyquire('lib/hermione', {
+                    './reporters/reporter': createReporter()
+                });
+
+                runner = mkRunnerStub_();
+                attachRunner = sandbox.stub();
+            });
+
+            it('should accept reporter as string', () => {
+                const reporter = 'reporter';
+                const options = {reporters: [reporter]};
+
+                return HermioneQuire.create().run(null, options).then(() => {
+                    assert.calledOnceWith(attachRunner, runner);
+                });
+            });
+
+            it('should throw if reporter is not found', () => {
+                const reporter = 'unknown-reporter';
+                const options = {reporters: [reporter]};
+
+                const run = () => HermioneQuire.create().run(null, options);
+
+                assert.throws(run, 'No such reporter: unknown-reporter');
+            });
+
+            it('should accept reporter as function', () => {
+                const reporter = createReporter();
+                const options = {reporters: [reporter]};
+
+                return HermioneQuire.create().run(null, options).then(() => {
+                    assert.calledOnceWith(attachRunner, runner);
+                });
+            });
+
+            it('should throw if reporter is nor string or function', () => {
+                const reporter = 1234;
+                const options = {reporters: [reporter]};
+
+                const run = () => HermioneQuire.create().run(null, options);
+
+                assert.throws(run, TypeError, 'Reporter must be a string or a function');
             });
         });
 
@@ -430,6 +498,15 @@ describe('hermione', () => {
 
                 return hermione.readTests(null, null, {silent: true})
                     .then(() => assert.notCalled(onInit));
+            });
+
+            it('should send INIT event only once', () => {
+                const onInit = sinon.spy();
+                const hermione = Hermione.create()
+                    .on(RunnerEvents.INIT, onInit);
+
+                return hermione.readTests().then(hermione.readTests())
+                    .then(() => assert.calledOnce(onInit));
             });
         });
 

--- a/test/lib/reporter/plain.js
+++ b/test/lib/reporter/plain.js
@@ -40,6 +40,25 @@ describe('Plain reporter', () => {
 
     afterEach(() => sandbox.restore());
 
+    describe('success tests report', () => {
+        it('should log correct info about test', () => {
+            test = mkTestStub_({
+                fullTitle: () => 'some test title',
+                title: 'test title',
+                file: 'some/path/file.js',
+                browserId: 'bro',
+                duration: '100'
+            });
+
+            emit(RunnerEvents.TEST_PASS, test);
+
+            assert.match(
+                getDeserializedResult(stdout),
+                /some test title \[bro\] - 100ms/
+            );
+        });
+    });
+
     const testStates = {
         RETRY: 'retried',
         TEST_FAIL: 'failed'
@@ -59,6 +78,7 @@ describe('Plain reporter', () => {
 
                 emit(RunnerEvents[event], test);
 
+                console.log(stdout);
                 assert.match(
                     getDeserializedResult(stdout),
                     /some test title \[bro\] - 100ms\s.+some\/path\/file.js\s.+some error stack/

--- a/test/lib/signal-handler.js
+++ b/test/lib/signal-handler.js
@@ -1,0 +1,61 @@
+'use strict';
+
+const clearRequire = require('clear-require');
+const Promise = require('bluebird');
+
+describe('lib/signal-handler', () => {
+    const sandbox = sinon.sandbox.create();
+
+    let signalHandler;
+
+    const getCallBySignal = (sig) => {
+        return process.on.getCalls().find((call) => call.args[0] === sig);
+    };
+
+    const sendSignal = (sig) => {
+        getCallBySignal(sig).args[1]();
+    };
+
+    beforeEach(() => {
+        sandbox.stub(process, 'on');
+        sandbox.stub(process, 'exit');
+
+        clearRequire('lib/signal-handler');
+        signalHandler = require('lib/signal-handler');
+    });
+
+    afterEach(() => sandbox.restore());
+
+    [
+        {signal: 'SIGHUP', exitCode: 129},
+        {signal: 'SIGINT', exitCode: 130},
+        {signal: 'SIGTERM', exitCode: 143}
+    ].forEach(({signal, exitCode}) => {
+        describe(signal, () => {
+            it(`should sign up for ${signal} event`, () => {
+                assert.calledWith(process.on, signal);
+            });
+
+            it('should emit and wait to exit', () => {
+                const afterHandler = sandbox.stub().named('afterHandler');
+                const handler = sandbox.stub().named('handler').resolves(Promise.delay(10).then(afterHandler));
+                signalHandler.on('exit', handler);
+
+                sendSignal(signal);
+
+                return Promise.delay(20).then(() => {
+                    assert.callOrder(handler, afterHandler, process.exit);
+                });
+            });
+
+            it('should force quit on second call', () => {
+                sandbox.stub(console, 'log');
+
+                sendSignal(signal);
+                sendSignal(signal);
+
+                assert.calledOnceWith(process.exit, exitCode);
+            });
+        });
+    });
+});

--- a/test/lib/worker/hermione-facade.js
+++ b/test/lib/worker/hermione-facade.js
@@ -1,5 +1,230 @@
 'use strict';
 
+const HermioneFacade = require('lib/worker/hermione-facade');
+const Hermione = require('lib/worker/hermione');
+const RuntimeConfig = require('lib/config/runtime-config');
+const Promise = require('bluebird');
+
 describe('worker/hermione-facade', () => {
-    it('TODO');
+    const sandbox = sinon.sandbox.create();
+
+    const runtimeConfigStub = {extend: () => {}};
+    const hermioneStub = {configPath: 'config/path', runTest: () => {}, config: {mergeWith: () => {}}};
+    let initCallbackArg;
+    let syncCallbackArg;
+
+    const sendMessageToInit = () => {
+        const callback = process.on.getCall(0).args[1];
+        callback(initCallbackArg);
+    };
+
+    const sendMessageToSync = () => {
+        const callback = process.on.getCall(1).args[1];
+        callback(syncCallbackArg);
+    };
+
+    beforeEach(() => {
+        process.send = sandbox.stub().named('process.send');
+        sandbox.stub(process, 'on');
+        sandbox.stub(RuntimeConfig, 'getInstance').returns(runtimeConfigStub);
+        sandbox.stub(Hermione, 'create').returns(hermioneStub);
+
+        initCallbackArg = {
+            event: 'master.init',
+            configPath: 'config/path',
+            runtimeConfig: {foo: 'runtime', bar: 'config'}
+        };
+        syncCallbackArg = {
+            event: 'master.syncConfig',
+            config: {'Harry Potter': 'loves Ron Weasley', system: {mochaOpts: {grep: 'grep'}}}
+        };
+    });
+
+    afterEach(() => {
+        process.send = undefined;
+        sandbox.restore();
+    });
+
+    describe('init', () => {
+        let hermioneFacade;
+        let init;
+
+        beforeEach(() => {
+            hermioneFacade = HermioneFacade.create();
+            init = sandbox.spy(hermioneFacade, 'init');
+
+            hermioneFacade.init();
+        });
+
+        it('should be called only once', () => {
+            hermioneFacade.init(); //again
+
+            assert.calledOnce(init);
+        });
+
+        it('should send worker.init event', () => {
+            return Promise.delay(10).then(() => {
+                assert.calledOnceWith(process.send, {event: 'worker.init'});
+            });
+        });
+
+        it('should subscribe on "message" event', () => {
+            return Promise.delay(10).then(() => {
+                assert.calledOnceWith(process.on, 'message');
+                assert.isFunction(process.on.getCall(0).args[1]);
+            });
+        });
+
+        describe('process.on "message"', () => {
+            let callback;
+
+            beforeEach(() => {
+                return Promise.delay(10).then(() => {
+                    callback = process.on.getCall(0).args[1];
+                });
+            });
+
+            it('should not fulfill without "message" event', () => {
+                return Promise.delay(100).then(() => {
+                    assert.isTrue(hermioneFacade.promise.isPending());
+                });
+            });
+
+            it('should not fulfill if event is not "master.init"', () => {
+                initCallbackArg.event = 'not.master.init';
+                callback(initCallbackArg);
+
+                return Promise.delay(100).then(() => {
+                    assert.isTrue(hermioneFacade.promise.isPending());
+                });
+            });
+
+            it('should fulfill with "master.init" event', () => {
+                callback(initCallbackArg);
+
+                return Promise.delay(100).then(() => {
+                    assert.isTrue(hermioneFacade.promise.isFulfilled());
+                });
+            });
+
+            it('should extend RuntimeConfig', () => {
+                sandbox.spy(runtimeConfigStub, 'extend');
+
+                callback(initCallbackArg);
+
+                return hermioneFacade.promise.then(() => {
+                    assert.calledOnceWith(runtimeConfigStub.extend, {foo: 'runtime', bar: 'config'});
+                });
+            });
+
+            it('should create Hermione instance', () => {
+                callback(initCallbackArg);
+
+                return hermioneFacade.promise.then(() => {
+                    assert.calledWith(Hermione.create, 'config/path');
+                });
+            });
+        });
+    });
+
+    describe('syncConfig', () => {
+        let hermioneFacade;
+        let syncConfig;
+
+        beforeEach(() => {
+            hermioneFacade = HermioneFacade.create();
+            syncConfig = sandbox.spy(hermioneFacade, 'syncConfig');
+
+            hermioneFacade.syncConfig();
+
+            return Promise.delay(10).then(sendMessageToInit);
+        });
+
+        it('should be called only once', () => {
+            hermioneFacade.syncConfig(); //again
+
+            assert.calledOnce(syncConfig);
+        });
+
+        it('should send worker.syncConfig event', () => {
+            return Promise.delay(100).then(() => {
+                assert.calledWith(process.send, {event: 'worker.syncConfig'});
+            });
+        });
+
+        it('should subscribe on "message" event', () => {
+            return Promise.delay(100).then(() => {
+                assert.calledTwice(process.on);
+                assert.calledWith(process.on, 'message');
+                assert.isFunction(process.on.getCall(1).args[1]);
+            });
+        });
+
+        describe('process.on "message"', () => {
+            let callback;
+
+            beforeEach(() => {
+                return Promise.delay(100).then(() => {
+                    callback = process.on.getCall(1).args[1];
+                });
+            });
+
+            it('should not fulfill without "message" event', () => {
+                return Promise.delay(100).then(() => {
+                    assert.isTrue(hermioneFacade.promise.isPending());
+                });
+            });
+
+            it('should not fulfill if event is not "master.syncConfig"', () => {
+                syncCallbackArg.event = 'not.master.syncConfig';
+                callback(syncCallbackArg);
+
+                return Promise.delay(100).then(() => {
+                    assert.isTrue(hermioneFacade.promise.isPending());
+                });
+            });
+
+            it('should fulfill with "master.init" event', () => {
+                callback(syncCallbackArg);
+
+                return Promise.delay(100).then(() => {
+                    assert.isTrue(hermioneFacade.promise.isFulfilled());
+                });
+            });
+
+            it('should remove grep and merge hermione\'s config', () => {
+                sandbox.spy(hermioneStub.config, 'mergeWith');
+
+                callback(syncCallbackArg);
+
+                assert.calledOnceWith(hermioneStub.config.mergeWith, {'Harry Potter': 'loves Ron Weasley', system: {mochaOpts: {}}});
+            });
+        });
+    });
+
+    describe('runTest', () => {
+        let hermioneFacade;
+        let syncConfig;
+
+        beforeEach(() => {
+            hermioneFacade = HermioneFacade.create();
+            syncConfig = sandbox.spy(hermioneFacade, 'syncConfig');
+        });
+
+        it('should sync config first', () => {
+            hermioneFacade.runTest();
+
+            Promise.delay(10).then(() => assert.called(syncConfig));
+        });
+
+        it('should run hermione tests', () => {
+            sandbox.spy(hermioneStub, 'runTest');
+            process.on.onFirstCall().callsFake(sendMessageToInit);
+            process.on.onSecondCall().callsFake(sendMessageToSync);
+
+            return hermioneFacade.runTest('arg1', 'arg2').then(() => {
+                assert.calledWith(hermioneStub.runTest, 'arg1', 'arg2');
+            });
+        });
+    });
 });

--- a/test/lib/worker/runner/index.js
+++ b/test/lib/worker/runner/index.js
@@ -1,5 +1,110 @@
 'use strict';
 
+const Runner = require('lib/worker/runner');
+const BrowserPool = require('lib/worker/runner/browser-pool');
+const MochaAdapter = require('lib/worker/runner/mocha-adapter');
+const BrowserAgent = require('lib/worker/runner/browser-agent');
+const EventEmitter = require('events').EventEmitter;
+const WorkerRunnerEvents = require('lib/worker/constants/runner-events');
+
 describe('worker/runner', () => {
-    it('TODO');
+    const sandbox = sinon.sandbox.create();
+
+    const mkMochaAdapterStub = () => {
+        const mocha = new EventEmitter();
+        mocha.attachTestFilter = sandbox.stub();
+        mocha.loadFiles = sandbox.stub();
+        mocha.runInSession = sandbox.stub();
+
+        sandbox.stub(MochaAdapter, 'create').returns(mocha);
+        return mocha;
+    };
+
+    beforeEach(() => {
+        sandbox.stub(BrowserPool, 'create').returns({browser: 'pool'});
+        sandbox.stub(MochaAdapter, 'prepare');
+    });
+
+    afterEach(() => sandbox.restore());
+
+    describe('constructor', () => {
+        it('should create browser pool', () => {
+            Runner.create({foo: 'bar'});
+
+            assert.calledOnceWith(BrowserPool.create, {foo: 'bar'});
+        });
+
+        it('should prepare Mocha', () => {
+            Runner.create();
+
+            assert.calledOnce(MochaAdapter.prepare);
+        });
+    });
+
+    describe('runTest', () => {
+        let runner;
+        let option;
+        let mochaAdapter;
+
+        beforeEach(() => {
+            sandbox.stub(BrowserAgent, 'create').withArgs('chrome', {browser: 'pool'}).returns({browser: 'agent'});
+            mochaAdapter = mkMochaAdapterStub();
+
+            runner = Runner.create({system: 'sys'});
+            option = {file: 'file.js', browserId: 'chrome', sessionId: '1234'};
+        });
+
+        it('should create mocha adapter', () => {
+            runner.runTest('title', option);
+
+            assert.calledWith(MochaAdapter.create, {browser: 'agent'}, 'sys');
+        });
+
+        it('should attach correct test filter', () => {
+            runner.runTest('title', option);
+
+            assert.calledOnce(mochaAdapter.attachTestFilter);
+            assert.isFunction(mochaAdapter.attachTestFilter.getCall(0).args[0]);
+        });
+
+        it('shoud filter tests by fullTitle', () => {
+            runner.runTest('world', option);
+
+            const tests = ['hello', 'world', 'test'].map((value) => {
+                return {fullTitle: () => value};
+            });
+            const filter = mochaAdapter.attachTestFilter.getCall(0).args[0];
+            const result = tests.filter(filter).map((test) => test.fullTitle());
+
+            assert.deepEqual(result, ['world']);
+        });
+
+        it('should load files', () => {
+            runner.runTest('title', option);
+
+            assert.calledOnceWith(mochaAdapter.loadFiles, 'file.js');
+        });
+
+        it('should run test is session', () => {
+            runner.runTest('title', option);
+
+            assert.calledOnceWith(mochaAdapter.runInSession, '1234');
+        });
+
+        it('should passthrough mochaAdapter events', () => {
+            runner.runTest('title', option);
+
+            [
+                WorkerRunnerEvents.BEFORE_FILE_READ,
+                WorkerRunnerEvents.AFTER_FILE_READ
+            ].forEach((event) => {
+                const spy = sandbox.spy().named(`${event} handler`);
+                runner.on(event, spy);
+
+                mochaAdapter.emit(event);
+
+                assert.calledOnce(spy);
+            });
+        });
+    });
 });

--- a/test/lib/worker/runner/mocha-adapter.js
+++ b/test/lib/worker/runner/mocha-adapter.js
@@ -1,13 +1,22 @@
 'use strict';
 
 const _ = require('lodash');
+const path = require('path');
+const q = require('q');
 const proxyquire = require('proxyquire');
-const BrowserAgent = require('gemini-core').BrowserAgent;
+const {BrowserAgent} = require('gemini-core');
 const RunnerEvents = require('lib/constants/runner-events');
+const Skip = require('lib/runner/mocha-runner/skip/');
 const MochaStub = require('../../_mocha');
+const crypto = require('lib/utils/crypto');
 
 describe('worker/mocha-adapter', () => {
+    const sandbox = sinon.sandbox.create();
+
     let MochaAdapter;
+    let browserAgent;
+    let clearRequire;
+    let proxyReporter;
 
     const mkBrowserStub_ = (opts) => {
         return _.defaults(opts || {}, {
@@ -17,19 +26,123 @@ describe('worker/mocha-adapter', () => {
     };
 
     const mkMochaAdapter_ = (config) => {
-        const browserAgent = sinon.createStubInstance(BrowserAgent);
-        browserAgent.getBrowser.resolves(mkBrowserStub_());
-
         return MochaAdapter.create(browserAgent, _.extend({patternsOnReject: []}, config));
     };
 
     beforeEach(() => {
+        browserAgent = sinon.createStubInstance(BrowserAgent);
+        browserAgent.getBrowser.returns(q(mkBrowserStub_()));
+
+        clearRequire = sandbox.stub().named('clear-require');
+        proxyReporter = sandbox.stub().named('proxy-reporter');
+
+        sandbox.stub(crypto, 'getShortMD5');
+
         MochaAdapter = proxyquire(require.resolve('lib/worker/runner/mocha-adapter'), {
-            'mocha': MochaStub
+            'mocha': MochaStub,
+            'clear-require': clearRequire,
+            '../../runner/mocha-runner/proxy-reporter': proxyReporter
         });
     });
 
-    it('TODO');
+    afterEach(() => sandbox.restore());
+
+    describe('timeouts', () => {
+        let mochaAdapter;
+        let action;
+
+        const addTest = ({duration, timeout}) => {
+            mochaAdapter = mkMochaAdapter_();
+            action = sinon.stub();
+            const test = new MochaStub.Test(null, {title: 'test', fn: q.delay(duration).then(action)});
+            if (timeout) {
+                test.timeout(timeout);
+            }
+
+            mochaAdapter.suite.addTest(test);
+        };
+
+        it('should complete test if no timeout', () => {
+            addTest({duration: 10});
+
+            return mochaAdapter.runInSession('1234').then(() => {
+                assert.calledOnce(action);
+            });
+        });
+
+        it('should complete test if timeout is bigger then test duration', () => {
+            addTest({duration: 10, timeout: 20});
+
+            return mochaAdapter.runInSession('1234').then(() => {
+                assert.calledOnce(action);
+            });
+        });
+
+        it('should abort test if timeout is smaller then test duration', () => {
+            addTest({duration: 20, timeout: 10});
+
+            return mochaAdapter.runInSession('1234').then(() => {
+                assert.notCalled(action);
+            });
+        });
+    });
+
+    describe('inject skip', () => {
+        let mochaAdapter;
+
+        beforeEach(() => {
+            browserAgent.getBrowser.returns(q(mkBrowserStub_()));
+            browserAgent.freeBrowser.returns(q());
+            sandbox.stub(Skip.prototype, 'handleEntity');
+
+            mochaAdapter = mkMochaAdapter_();
+        });
+
+        it('should apply skip to test', () => {
+            const test = new MochaStub.Test();
+
+            mochaAdapter.suite.addTest(test);
+
+            return mochaAdapter.runInSession('1234')
+                .then(() => {
+                    assert.called(Skip.prototype.handleEntity);
+                    assert.calledWith(Skip.prototype.handleEntity, test);
+                });
+        });
+
+        it('should apply skip to suite', () => {
+            const nestedSuite = MochaStub.Suite.create();
+
+            mochaAdapter.suite.addSuite(nestedSuite);
+
+            return mochaAdapter.runInSession('1234')
+                .then(() => {
+                    assert.called(Skip.prototype.handleEntity);
+                    assert.calledWith(Skip.prototype.handleEntity, nestedSuite);
+                });
+        });
+    });
+
+    describe('extend test API', () => {
+        it('should add "id" method for test', () => {
+            const mochaAdapter = mkMochaAdapter_();
+            const test = new MochaStub.Test();
+            mochaAdapter.suite.addTest(test);
+
+            assert.isFunction(test.id);
+        });
+
+        it('should generate unique id for test', () => {
+            crypto.getShortMD5.withArgs('suite test').returns('12345');
+
+            const mochaAdapter = mkMochaAdapter_();
+            const test = new MochaStub.Test(null, {title: 'test'});
+            mochaAdapter.suite.title = 'suite';
+            mochaAdapter.suite.addTest(test);
+
+            assert.equal(test.id(), '12345');
+        });
+    });
 
     describe('inject contexts', () => {
         it('should extend test with hermione context', () => {
@@ -39,6 +152,230 @@ describe('worker/mocha-adapter', () => {
 
             return mochaAdapter.runInSession()
                 .then((data) => assert.property(data, 'hermioneCtx'));
+        });
+    });
+
+    describe('passthrough mocha events', () => {
+        let mochaAdapter;
+
+        beforeEach(() => {
+            mochaAdapter = mkMochaAdapter_();
+            sandbox.spy(mochaAdapter, 'emit').named('emit');
+        });
+
+        const passthroughMochaEvents_ = () => {
+            const Reporter = MochaStub.lastInstance.reporter.lastCall.args[0];
+            new Reporter(); // eslint-disable-line no-new
+        };
+
+        it('should set mocha reporter as proxy reporter in order to proxy events to emit fn', () => {
+            passthroughMochaEvents_();
+
+            assert.calledOnce(proxyReporter);
+            assert.calledWithNew(proxyReporter);
+        });
+
+        it('should pass to proxy reporter emit fn', () => {
+            passthroughMochaEvents_();
+
+            const emit_ = proxyReporter.firstCall.args[0];
+            emit_('some-event', {some: 'data'});
+
+            assert.calledOnceWith(mochaAdapter.emit, 'some-event', sinon.match({some: 'data'}));
+        });
+
+        it('should pass to proxy reporter getter for requested browser', () => {
+            const browser = mkBrowserStub_();
+            browserAgent.getBrowser.returns(q(browser));
+            passthroughMochaEvents_();
+
+            MochaStub.lastInstance.updateSuiteTree((suite) => suite.addTest());
+
+            return mochaAdapter.runInSession('1234')
+                .then(() => {
+                    const getBrowser = proxyReporter.lastCall.args[1];
+                    assert.equal(browser, getBrowser());
+                });
+        });
+
+        it('should pass to proxy reporter getter for browser id if browser not requested', () => {
+            browserAgent.browserId = 'some-browser';
+
+            passthroughMochaEvents_();
+
+            const getBrowser = proxyReporter.lastCall.args[1];
+            assert.deepEqual(getBrowser(), {id: 'some-browser'});
+        });
+
+        describe('if event handler throws', () => {
+            const initBadHandler_ = (event, handler) => {
+                mochaAdapter.on(event, handler);
+
+                passthroughMochaEvents_();
+                return proxyReporter.firstCall.args[0];
+            };
+
+            it('proxy should rethrow error', () => {
+                const emit_ = initBadHandler_('foo', () => {
+                    throw new Error(new Error('bar'));
+                });
+
+                assert.throws(() => emit_('foo'), /bar/);
+            });
+
+            it('run should be rejected', () => {
+                const emit_ = initBadHandler_('foo', () => {
+                    throw new Error('bar');
+                });
+
+                const promise = mochaAdapter.runInSession('1234');
+
+                const originalRun = MochaStub.lastInstance.run.bind(MochaStub.lastInstance);
+                sandbox.stub(MochaStub.lastInstance, 'run').callsFake((cb) => {
+                    try {
+                        emit_('foo');
+                    } catch (e) {
+                        // eslint иди лесом
+                    }
+                    originalRun(cb);
+                });
+
+                return assert.isRejected(promise, /bar/);
+            });
+        });
+
+        describe('file events', () => {
+            beforeEach(() => MochaAdapter.init());
+            afterEach(() => delete global.hermione);
+
+            _.forEach({
+                'pre-require': 'BEFORE_FILE_READ',
+                'post-require': 'AFTER_FILE_READ'
+            }, (hermioneEvent, mochaEvent) => {
+                it(`should emit ${hermioneEvent} on mocha ${mochaEvent}`, () => {
+                    browserAgent.browserId = 'bro';
+
+                    MochaStub.lastInstance.suite.emit(mochaEvent, {}, '/some/file.js');
+
+                    assert.calledOnce(mochaAdapter.emit);
+                    assert.calledWith(mochaAdapter.emit, RunnerEvents[hermioneEvent], {
+                        file: '/some/file.js',
+                        hermione: global.hermione,
+                        browser: 'bro',
+                        suite: mochaAdapter.suite
+                    });
+                });
+            });
+        });
+    });
+
+    describe('attachTestFilter', () => {
+        let mochaAdapter;
+        let filter;
+
+        beforeEach(() => {
+            mochaAdapter = mkMochaAdapter_();
+            filter = sinon.spy((test) => test.title.startsWith('button'));
+            mochaAdapter.attachTestFilter(filter);
+        });
+
+        it('should call filter for each test', () => {
+            const buttonTest1 = new MochaStub.Test(null, {title: 'button-accept'});
+            const buttonTest2 = new MochaStub.Test(null, {title: 'button-decline'});
+
+            mochaAdapter.suite
+                .addTest(buttonTest1)
+                .addTest(buttonTest2);
+
+            assert.calledWith(filter.getCall(0), buttonTest1);
+            assert.calledWith(filter.getCall(1), buttonTest2);
+        });
+
+        it('should filter tests', () => {
+            const buttonTest1 = new MochaStub.Test(null, {title: 'button-accept'});
+            const buttonTest2 = new MochaStub.Test(null, {title: 'button-decline'});
+            const labelTest = new MochaStub.Test(null, {title: 'label'});
+
+            mochaAdapter.suite
+                .addTest(buttonTest1)
+                .addTest(labelTest)
+                .addTest(buttonTest2);
+
+            assert.deepEqual(mochaAdapter.tests, [buttonTest1, buttonTest2]);
+            assert.deepEqual(mochaAdapter.suite.tests, [buttonTest1, buttonTest2]);
+        });
+
+        it('should filter tests from child suites', () => {
+            const buttonTest1 = new MochaStub.Test(null, {title: 'button-accept'});
+            const buttonTest2 = new MochaStub.Test(null, {title: 'button-decline'});
+            const labelTest1 = new MochaStub.Test(null, {title: 'label-small'});
+            const labelTest2 = new MochaStub.Test(null, {title: 'label-large'});
+
+            const suite1 = new MochaStub.Suite(null, 'child-suite-1');
+            const suite2 = new MochaStub.Suite(null, 'child-suite-2');
+            mochaAdapter.suite
+                .addSuite(suite1)
+                .addSuite(suite2);
+            suite1
+                .addTest(buttonTest1)
+                .addTest(labelTest1);
+            suite2
+                .addTest(labelTest2)
+                .addTest(buttonTest2);
+
+            assert.deepEqual(mochaAdapter.tests, [buttonTest1, buttonTest2]);
+            assert.deepEqual(suite1.tests, [buttonTest1]);
+            assert.deepEqual(suite2.tests, [buttonTest2]);
+        });
+    });
+
+    describe('loadFiles', () => {
+        it('should be chainable', () => {
+            const mochaAdapter = mkMochaAdapter_();
+
+            assert.deepEqual(mochaAdapter.loadFiles(['path/to/file']), mochaAdapter);
+        });
+
+        it('should load files', () => {
+            const mochaAdapter = mkMochaAdapter_();
+
+            mochaAdapter.loadFiles(['path/to/file']);
+
+            assert.calledOnceWith(MochaStub.lastInstance.addFile, 'path/to/file');
+        });
+
+        it('should load a single file', () => {
+            const mochaAdapter = mkMochaAdapter_();
+
+            mochaAdapter.loadFiles('path/to/file');
+
+            assert.calledOnceWith(MochaStub.lastInstance.addFile, 'path/to/file');
+        });
+
+        it('should clear require cache for file before adding', () => {
+            const mochaAdapter = mkMochaAdapter_();
+
+            mochaAdapter.loadFiles(['path/to/file']);
+
+            assert.calledOnceWith(clearRequire, path.resolve('path/to/file'));
+            assert.callOrder(clearRequire, MochaStub.lastInstance.addFile);
+        });
+
+        it('should load file after add', () => {
+            const mochaAdapter = mkMochaAdapter_();
+
+            mochaAdapter.loadFiles(['path/to/file']);
+
+            assert.calledOnce(MochaStub.lastInstance.loadFiles);
+            assert.callOrder(MochaStub.lastInstance.addFile, MochaStub.lastInstance.loadFiles);
+        });
+
+        it('should flush files after load', () => {
+            const mochaAdapter = mkMochaAdapter_();
+
+            mochaAdapter.loadFiles(['path/to/file']);
+
+            assert.deepEqual(MochaStub.lastInstance.files, []);
         });
     });
 


### PR DESCRIPTION
Что возможно было покрыть тестами, покрыл. Оставшиеся желтые участки – модули из одной функции, которые нет смысла проверять. Или такие случаи, как
```js
process.on('uncaughtException', (err) => {
    logger.error(err.stack);
    process.exit(1);
});
```

__Статистика по каждой папке__
До
<img width="1274" alt="coverage-before" src="https://user-images.githubusercontent.com/25789153/36585727-be42a868-1887-11e8-81fd-5564af253a6a.png">
После
<img width="1273" alt="coverage-after" src="https://user-images.githubusercontent.com/25789153/36585729-c355bfe8-1887-11e8-9082-6fd70b53912b.png">

__Корневая папка__
До
<img width="1276" alt="coverage-lib-before" src="https://user-images.githubusercontent.com/25789153/36586093-0a629068-1889-11e8-9db2-f5eefd921a98.png">
После
<img width="1277" alt="coverage-lib-after" src="https://user-images.githubusercontent.com/25789153/36586102-149c7c74-1889-11e8-90cc-acff82a49719.png">

__worker__
До
<img width="1279" alt="coverage-worker-before" src="https://user-images.githubusercontent.com/25789153/36586120-28d4f892-1889-11e8-8981-3ae580935a26.png">
После
<img width="1275" alt="coverage-worker-after" src="https://user-images.githubusercontent.com/25789153/36586128-2e241f62-1889-11e8-850b-be97385f436d.png">

__worker-runner__
До
<img width="1277" alt="coverage-worker-runner-before" src="https://user-images.githubusercontent.com/25789153/36586142-394e4a52-1889-11e8-87e2-f010240a75a9.png">
После
<img width="1276" alt="coverage-worker-runner-after" src="https://user-images.githubusercontent.com/25789153/36586147-3e441c26-1889-11e8-9f90-6a6ff6abc468.png">



