### PR TITLE
Test-cover lib/

### DIFF
--- a/lib/signal-handler.js
+++ b/lib/signal-handler.js
@@ -1,6 +1,7 @@
 'use strict';
 
-const AsyncEmitter = require('gemini-core').events.AsyncEmitter;
+const {AsyncEmitter} = require('gemini-core').events;
+const {log} = require('./utils/logger');
 const signalHandler = new AsyncEmitter();
 
 signalHandler.setMaxListeners(0);
@@ -18,7 +19,7 @@ function notifyAndExit(signalNo) {
 
     return function() {
         if (callCount++ > 0) {
-            console.log('Force quit.');
+            log('Force quit.');
             process.exit(exitCode);
         }
 

--- a/test/lib/signal-handler.js
+++ b/test/lib/signal-handler.js
@@ -1,0 +1,62 @@
+'use strict';
+
+const logger = require('lib/utils/logger');
+const clearRequire = require('clear-require');
+const Promise = require('bluebird');
+
+describe('lib/signal-handler', () => {
+    const sandbox = sinon.sandbox.create();
+
+    let signalHandler;
+
+    const getCallBySignal = (sig) => {
+        return process.on.getCalls().find((call) => call.args[0] === sig);
+    };
+
+    const sendSignal = (sig) => {
+        getCallBySignal(sig).args[1]();
+    };
+
+    beforeEach(() => {
+        sandbox.stub(process, 'on');
+        sandbox.stub(process, 'exit');
+        sandbox.stub(logger, 'log');
+
+        clearRequire('lib/signal-handler');
+        signalHandler = require('lib/signal-handler');
+    });
+
+    afterEach(() => sandbox.restore());
+
+    [
+        {signal: 'SIGHUP', exitCode: 129},
+        {signal: 'SIGINT', exitCode: 130},
+        {signal: 'SIGTERM', exitCode: 143}
+    ].forEach(({signal, exitCode}) => {
+        describe(signal, () => {
+            it(`should subscribe to ${signal} event`, () => {
+                assert.calledWith(process.on, signal);
+            });
+
+            it('should emit and wait for exit', () => {
+                const afterHandler = sandbox.stub().named('afterHandler');
+                const handler = sandbox.stub().named('handler')
+                    .returns(Promise.delay(10).then(afterHandler));
+                signalHandler.on('exit', handler);
+
+                sendSignal(signal);
+
+                return Promise.delay(20).then(() => {
+                    assert.callOrder(handler, afterHandler, process.exit);
+                });
+            });
+
+            it('should force quit on second call', () => {
+                sendSignal(signal);
+                sendSignal(signal);
+
+                assert.calledOnceWith(process.exit, exitCode);
+            });
+        });
+    });
+});


### PR DESCRIPTION
Один из 4-х пул риквестов в рамках одной задачи – покрыть гермиону тестами. Конечный результат в картинках, соответственно, представлен по 4-м пул риквестам.

Этот отвечает за покрытие корневых файлов каталога `lib`.

__До__
<img width="1276" alt="coverage-lib-before" src="https://user-images.githubusercontent.com/25789153/36667648-4786023e-1af7-11e8-9312-c4d562c7000a.png">

__После__
<img width="1277" alt="coverage-lib-after" src="https://user-images.githubusercontent.com/25789153/36667689-672dbc58-1af7-11e8-8f47-663ab6c0f2d1.png">

__В целом до__
<img width="1274" alt="coverage-before" src="https://user-images.githubusercontent.com/25789153/36667733-8f0090fc-1af7-11e8-9c20-7e3c8f144fbe.png">

__В целом после__
<img width="1273" alt="coverage-after" src="https://user-images.githubusercontent.com/25789153/36667738-9968882e-1af7-11e8-8f35-86525ca2231c.png">
