### PR TITLE
Test-cover: plain reporter

### DIFF
--- a/test/lib/reporter/plain.js
+++ b/test/lib/reporter/plain.js
@@ -40,6 +40,24 @@ describe('Plain reporter', () => {
 
     afterEach(() => sandbox.restore());
 
+    describe('success tests report', () => {
+        it('should log correct info about test', () => {
+            test = mkTestStub_({
+                fullTitle: () => 'some test title',
+                title: 'test title',
+                browserId: 'bro',
+                duration: '100'
+            });
+
+            emit(RunnerEvents.TEST_PASS, test);
+
+            assert.match(
+                getDeserializedResult(stdout),
+                /some test title \[bro\] - 100ms/
+            );
+        });
+    });
+
     const testStates = {
         RETRY: 'retried',
         TEST_FAIL: 'failed'


### PR DESCRIPTION
Один из 4-х пул риквестов в рамках одной задачи – покрыть гермиону тестами. Конечный результат в картинках, соответственно, представлен по 4-м пул риквестам.

Этот отвечает за покрытие `plain reporter`.

__В целом до__
<img width="1274" alt="coverage-before" src="https://user-images.githubusercontent.com/25789153/36668073-c4bd487e-1af8-11e8-86c2-d755eb0ac4aa.png">

__В целом после__
<img width="1273" alt="coverage-after" src="https://user-images.githubusercontent.com/25789153/36668077-cb8e7c04-1af8-11e8-81c8-26707766f638.png">



