### PR TITLE
Test-cover: worker/runner

### DIFF
--- a/test/lib/worker/runner/index.js
+++ b/test/lib/worker/runner/index.js
@@ -1,33 +1,111 @@
 'use strict';
 
 const Runner = require('lib/worker/runner');
+const BrowserPool = require('lib/worker/runner/browser-pool');
 const MochaAdapter = require('lib/worker/runner/mocha-adapter');
+const BrowserAgent = require('lib/worker/runner/browser-agent');
+const EventEmitter = require('events').EventEmitter;
+const WorkerRunnerEvents = require('lib/worker/constants/runner-events');
 
 describe('worker/runner', () => {
     const sandbox = sinon.sandbox.create();
 
+    const mkMochaAdapterStub = () => {
+        const mocha = new EventEmitter();
+        mocha.attachTestFilter = sandbox.stub();
+        mocha.loadFiles = sandbox.stub();
+        mocha.runInSession = sandbox.stub();
+
+        sandbox.stub(MochaAdapter, 'create').returns(mocha);
+        return mocha;
+    };
+
     beforeEach(() => {
-        sandbox.stub(MochaAdapter, 'create').returns(Object.create(MochaAdapter.prototype));
-        sandbox.stub(MochaAdapter.prototype);
+        sandbox.stub(BrowserPool, 'create').returns({browser: 'pool'});
+        sandbox.stub(MochaAdapter, 'prepare');
     });
 
     afterEach(() => sandbox.restore());
 
-    it('TODO');
+    describe('constructor', () => {
+        it('should create browser pool', () => {
+            Runner.create({foo: 'bar'});
+
+            assert.calledOnceWith(BrowserPool.create, {foo: 'bar'});
+        });
+
+        it('should prepare Mocha', () => {
+            Runner.create();
+
+            assert.calledOnce(MochaAdapter.prepare);
+        });
+    });
 
     describe('runTest', () => {
-        it('should create mocha adapter with merged system and browser config', () => {
+        let runner;
+        let option;
+        let mochaAdapter;
+
+        beforeEach(() => {
+            sandbox.stub(BrowserAgent, 'create')
+                .withArgs('chrome', {browser: 'pool'})
+                .returns({browser: 'agent'});
+            mochaAdapter = mkMochaAdapterStub();
+
             const config = {
-                system: {foo: 'bar'},
+                system: {system: 'sys'},
                 forBrowser: () => ({baz: 'qux'})
             };
-            const runner = Runner.create(config);
+            runner = Runner.create(config);
+            option = {file: 'file.js', browserId: 'chrome', sessionId: '1234'};
+        });
 
+        it('should create mocha adapter with merged system and browser config', () => {
             runner.runTest(null, {});
 
             assert.calledOnceWith(MochaAdapter.create, sinon.match.any, {
-                foo: 'bar',
+                system: 'sys',
                 baz: 'qux'
+            });
+        });
+
+        it('should filter tests by fullTitle', () => {
+            runner.runTest('world', option);
+
+            const tests = ['hello', 'world', 'test'].map((value) => {
+                return {fullTitle: () => value};
+            });
+            const filter = mochaAdapter.attachTestFilter.getCall(0).args[0];
+            const result = tests.filter(filter).map((test) => test.fullTitle());
+
+            assert.deepEqual(result, ['world']);
+        });
+
+        it('should load files', () => {
+            runner.runTest('title', option);
+
+            assert.calledOnceWith(mochaAdapter.loadFiles, 'file.js');
+        });
+
+        it('should run test is session', () => {
+            runner.runTest('title', option);
+
+            assert.calledOnceWith(mochaAdapter.runInSession, '1234');
+        });
+
+        it('should passthrough mochaAdapter events', () => {
+            runner.runTest('title', option);
+
+            [
+                WorkerRunnerEvents.BEFORE_FILE_READ,
+                WorkerRunnerEvents.AFTER_FILE_READ
+            ].forEach((event) => {
+                const spy = sandbox.spy().named(`${event} handler`);
+                runner.on(event, spy);
+
+                mochaAdapter.emit(event);
+
+                assert.calledOnce(spy);
             });
         });
     });

--- a/test/lib/worker/runner/mocha-adapter.js
+++ b/test/lib/worker/runner/mocha-adapter.js
@@ -1,16 +1,24 @@
 'use strict';
 
 const _ = require('lodash');
+const path = require('path');
+const q = require('q');
 const proxyquire = require('proxyquire');
-const BrowserAgent = require('gemini-core').BrowserAgent;
+const {BrowserAgent} = require('gemini-core');
 const RunnerEvents = require('lib/constants/runner-events');
 const Browser = require('lib/browser/existing-browser');
 const logger = require('lib/utils/logger');
+const Skip = require('lib/runner/mocha-runner/skip/');
 const MochaStub = require('../../_mocha');
+const crypto = require('lib/utils/crypto');
 
 describe('worker/mocha-adapter', () => {
     const sandbox = sinon.sandbox.create();
+
     let MochaAdapter;
+    let browserAgent;
+    let clearRequire;
+    let proxyReporter;
 
     const mkBrowserStub_ = () => {
         const browser = sinon.createStubInstance(Browser);
@@ -19,6 +27,7 @@ describe('worker/mocha-adapter', () => {
         };
 
         Object.defineProperty(browser, 'publicAPI', {get: () => wdio});
+        browser.updateChanges = sinon.stub();
 
         return browser;
     };
@@ -28,7 +37,6 @@ describe('worker/mocha-adapter', () => {
             patternsOnReject: [],
             screenshotOnReject: true
         });
-        const browserAgent = Object.create(BrowserAgent.prototype);
         const mochaAdapter = MochaAdapter.create(browserAgent, config);
 
         MochaStub.lastInstance.updateSuiteTree((suite) => {
@@ -46,19 +54,120 @@ describe('worker/mocha-adapter', () => {
     };
 
     beforeEach(() => {
-        sandbox.stub(BrowserAgent.prototype);
-        BrowserAgent.prototype.getBrowser.resolves(mkBrowserStub_());
+        browserAgent = sinon.createStubInstance(BrowserAgent);
+        browserAgent.getBrowser.resolves(mkBrowserStub_());
+
+        clearRequire = sandbox.stub().named('clear-require');
+        proxyReporter = sandbox.stub().named('proxy-reporter');
+
+        sandbox.stub(crypto, 'getShortMD5');
+        sandbox.stub(logger);
 
         MochaAdapter = proxyquire(require.resolve('lib/worker/runner/mocha-adapter'), {
-            'mocha': MochaStub
+            'mocha': MochaStub,
+            'clear-require': clearRequire,
+            '../../runner/mocha-runner/proxy-reporter': proxyReporter
         });
-
-        sandbox.stub(logger);
     });
 
     afterEach(() => sandbox.restore());
 
-    it('TODO');
+    describe('timeouts', () => {
+        let mochaAdapter;
+        let action;
+
+        const addTest = ({duration, timeout}) => {
+            mochaAdapter = mkMochaAdapter_();
+            action = sinon.stub().named('action');
+            const test = new MochaStub.Test(null, {title: 'test', fn: () => q.delay(duration).then(action)});
+            if (timeout) {
+                test.timeout(timeout);
+            }
+
+            mochaAdapter.suite.addTest(test);
+        };
+
+        it('should complete test if no timeout', () => {
+            addTest({duration: 10});
+
+            return mochaAdapter.runInSession('1234').then(() => {
+                assert.calledOnce(action);
+            });
+        });
+
+        it('should complete test if timeout is bigger then test duration', () => {
+            addTest({duration: 10, timeout: 20});
+
+            return mochaAdapter.runInSession('1234').then(() => {
+                assert.calledOnce(action);
+            });
+        });
+
+        it('should abort test on timeout', () => {
+            addTest({duration: 20, timeout: 10});
+
+            const promise = mochaAdapter.runInSession('1234')
+                .finally(() => assert.notCalled(action));
+
+            return assert.isRejected(promise, /operation timed out/);
+        });
+    });
+
+    describe('extend test API', () => {
+        it('should add "id" method for test', () => {
+            const mochaAdapter = mkMochaAdapter_();
+            const test = new MochaStub.Test();
+            mochaAdapter.suite.addTest(test);
+
+            assert.isFunction(test.id);
+        });
+
+        it('should generate unique id for test', () => {
+            crypto.getShortMD5.withArgs('suite test').returns('12345');
+
+            const mochaAdapter = mkMochaAdapter_();
+            const test = new MochaStub.Test(null, {title: 'test'});
+            mochaAdapter.suite.title = 'suite';
+            mochaAdapter.suite.addTest(test);
+
+            assert.equal(test.id(), '12345');
+        });
+    });
+
+    describe('inject skip', () => {
+        let mochaAdapter;
+
+        beforeEach(() => {
+            browserAgent.freeBrowser.resolves();
+            sandbox.stub(Skip.prototype, 'handleEntity');
+
+            mochaAdapter = mkMochaAdapter_();
+        });
+
+        it('should apply skip to test', () => {
+            const test = new MochaStub.Test();
+
+            mochaAdapter.suite.addTest(test);
+
+            return mochaAdapter.runInSession('1234')
+                .then(() => {
+                    assert.called(Skip.prototype.handleEntity);
+                    assert.calledWith(Skip.prototype.handleEntity, test);
+                });
+        });
+
+        it('should apply skip to suite', () => {
+            const nestedSuite = MochaStub.Suite.create();
+
+            mochaAdapter.suite.addSuite(nestedSuite);
+
+            return mochaAdapter.runInSession('1234')
+                .then(() => {
+                    assert.called(Skip.prototype.handleEntity);
+                    assert.calledWith(Skip.prototype.handleEntity, nestedSuite);
+                });
+        });
+    });
 
     describe('inject contexts', () => {
         it('should extend test with hermione context before run', async () => {
@@ -67,6 +176,218 @@ describe('worker/mocha-adapter', () => {
             MochaStub.lastInstance.updateSuiteTree((suite) => suite.addTest(test));
 
             assert.property(test, 'hermioneCtx');
+        });
+    });
+
+    describe('passthrough mocha events', () => {
+        let mochaAdapter;
+
+        beforeEach(() => {
+            mochaAdapter = mkMochaAdapter_();
+            sandbox.spy(mochaAdapter, 'emit').named('emit');
+        });
+
+        const passthroughMochaEvents_ = () => {
+            const Reporter = MochaStub.lastInstance.reporter.lastCall.args[0];
+            new Reporter(); // eslint-disable-line no-new
+        };
+
+        it('should set mocha reporter as proxy reporter in order to proxy events to emit function', () => {
+            passthroughMochaEvents_();
+
+            assert.calledOnce(proxyReporter);
+            assert.calledWithNew(proxyReporter);
+        });
+
+        it('should pass emit function', () => {
+            passthroughMochaEvents_();
+
+            const emit_ = proxyReporter.firstCall.args[0];
+            emit_('some-event', {some: 'data'});
+
+            assert.calledOnceWith(mochaAdapter.emit, 'some-event', sinon.match({some: 'data'}));
+        });
+
+        it('should pass getter for requested browser', () => {
+            const browser = mkBrowserStub_();
+            browserAgent.getBrowser.resolves(browser);
+            passthroughMochaEvents_();
+
+            MochaStub.lastInstance.updateSuiteTree((suite) => suite.addTest());
+
+            return mochaAdapter.runInSession('1234')
+                .then(() => {
+                    const getBrowser = proxyReporter.lastCall.args[1];
+                    assert.equal(browser, getBrowser());
+                });
+        });
+
+        it('should pass getter for browser id if browser not requested', () => {
+            browserAgent.browserId = 'some-browser';
+
+            passthroughMochaEvents_();
+
+            const getBrowser = proxyReporter.lastCall.args[1];
+            assert.deepEqual(getBrowser(), {id: 'some-browser'});
+        });
+
+        describe('if event handler throws', () => {
+            const initBadHandler_ = (event, handler) => {
+                mochaAdapter.on(event, handler);
+
+                passthroughMochaEvents_();
+                return proxyReporter.firstCall.args[0];
+            };
+
+            it('proxy should rethrow error', () => {
+                const emit_ = initBadHandler_('foo', () => {
+                    throw new Error(new Error('bar'));
+                });
+
+                assert.throws(() => emit_('foo'), /bar/);
+            });
+
+            it('run should be rejected', () => {
+                const emit_ = initBadHandler_('foo', () => {
+                    throw new Error('bar');
+                });
+
+                const promise = mochaAdapter.runInSession('1234');
+
+                const originalRun = MochaStub.lastInstance.run.bind(MochaStub.lastInstance);
+                sandbox.stub(MochaStub.lastInstance, 'run').callsFake((cb) => {
+                    try {
+                        emit_('foo');
+                    } catch (e) {
+                        // eslint-disable-line
+                    }
+                    originalRun(cb);
+                });
+
+                return assert.isRejected(promise, /bar/);
+            });
+        });
+
+        describe('file events', () => {
+            beforeEach(() => MochaAdapter.init());
+            afterEach(() => delete global.hermione);
+
+            _.forEach({
+                'pre-require': 'BEFORE_FILE_READ',
+                'post-require': 'AFTER_FILE_READ'
+            }, (hermioneEvent, mochaEvent) => {
+                it(`should emit ${hermioneEvent} on mocha ${mochaEvent}`, () => {
+                    browserAgent.browserId = 'bro';
+
+                    MochaStub.lastInstance.suite.emit(mochaEvent, {}, '/some/file.js');
+
+                    assert.calledOnce(mochaAdapter.emit);
+                    assert.calledWith(mochaAdapter.emit, RunnerEvents[hermioneEvent], {
+                        file: '/some/file.js',
+                        hermione: global.hermione,
+                        browser: 'bro',
+                        suite: mochaAdapter.suite
+                    });
+                });
+            });
+        });
+    });
+
+    describe('attachTestFilter', () => {
+        let mochaAdapter;
+        let filter;
+
+        beforeEach(() => {
+            mochaAdapter = mkMochaAdapter_();
+            filter = sinon.spy((test) => test.title.startsWith('button'));
+            mochaAdapter.attachTestFilter(filter);
+        });
+
+        it('should filter tests', () => {
+            const buttonTest1 = new MochaStub.Test(null, {title: 'button-accept'});
+            const buttonTest2 = new MochaStub.Test(null, {title: 'button-decline'});
+            const labelTest = new MochaStub.Test(null, {title: 'label'});
+
+            mochaAdapter.suite
+                .addTest(buttonTest1)
+                .addTest(labelTest)
+                .addTest(buttonTest2);
+
+            assert.deepEqual(mochaAdapter.tests, [buttonTest1, buttonTest2]);
+            assert.deepEqual(mochaAdapter.suite.tests, [buttonTest1, buttonTest2]);
+        });
+
+        it('should filter tests from child suites', () => {
+            const buttonTest1 = new MochaStub.Test(null, {title: 'button-accept'});
+            const buttonTest2 = new MochaStub.Test(null, {title: 'button-decline'});
+            const labelTest1 = new MochaStub.Test(null, {title: 'label-small'});
+            const labelTest2 = new MochaStub.Test(null, {title: 'label-large'});
+
+            const suite1 = new MochaStub.Suite(null, 'child-suite-1');
+            const suite2 = new MochaStub.Suite(null, 'child-suite-2');
+            mochaAdapter.suite
+                .addSuite(suite1)
+                .addSuite(suite2);
+            suite1
+                .addTest(buttonTest1)
+                .addTest(labelTest1);
+            suite2
+                .addTest(labelTest2)
+                .addTest(buttonTest2);
+
+            assert.deepEqual(mochaAdapter.tests, [buttonTest1, buttonTest2]);
+            assert.deepEqual(suite1.tests, [buttonTest1]);
+            assert.deepEqual(suite2.tests, [buttonTest2]);
+        });
+    });
+
+    describe('loadFiles', () => {
+        it('should be chainable', () => {
+            const mochaAdapter = mkMochaAdapter_();
+
+            assert.deepEqual(mochaAdapter.loadFiles(['path/to/file']), mochaAdapter);
+        });
+
+        it('should load files', () => {
+            const mochaAdapter = mkMochaAdapter_();
+
+            mochaAdapter.loadFiles(['path/to/file']);
+
+            assert.calledOnceWith(MochaStub.lastInstance.addFile, 'path/to/file');
+        });
+
+        it('should load a single file', () => {
+            const mochaAdapter = mkMochaAdapter_();
+
+            mochaAdapter.loadFiles('path/to/file');
+
+            assert.calledOnceWith(MochaStub.lastInstance.addFile, 'path/to/file');
+        });
+
+        it('should clear require cache for file before adding', () => {
+            const mochaAdapter = mkMochaAdapter_();
+
+            mochaAdapter.loadFiles(['path/to/file']);
+
+            assert.calledOnceWith(clearRequire, path.resolve('path/to/file'));
+            assert.callOrder(clearRequire, MochaStub.lastInstance.addFile);
+        });
+
+        it('should load file after add', () => {
+            const mochaAdapter = mkMochaAdapter_();
+
+            mochaAdapter.loadFiles(['path/to/file']);
+
+            assert.calledOnce(MochaStub.lastInstance.loadFiles);
+            assert.callOrder(MochaStub.lastInstance.addFile, MochaStub.lastInstance.loadFiles);
+        });
+
+        it('should flush files after load', () => {
+            const mochaAdapter = mkMochaAdapter_();
+
+            mochaAdapter.loadFiles(['path/to/file']);
+
+            assert.deepEqual(MochaStub.lastInstance.files, []);
         });
     });
 
@@ -109,7 +430,7 @@ describe('worker/mocha-adapter', () => {
 
         beforeEach(() => {
             browser = mkBrowserStub_();
-            BrowserAgent.prototype.getBrowser.resolves(browser);
+            browserAgent.getBrowser.resolves(browser);
         });
 
         it('should attach screenshot to error on test fail', async () => {


### PR DESCRIPTION
Один из 4-х пул риквестов в рамках одной задачи – покрыть гермиону тестами. Конечный результат в картинках, соответственно, представлен по 4-м пул риквестам.

Этот отвечает за покрытие файлов каталога `lib/worker/runner`.

__До__
<img width="1277" alt="coverage-worker-runner-before" src="https://user-images.githubusercontent.com/25789153/36668724-dde91d80-1afa-11e8-81e9-394a10285942.png">

__После__
<img width="1276" alt="coverage-worker-runner-after" src="https://user-images.githubusercontent.com/25789153/36668733-e3c4c484-1afa-11e8-995d-ddcf076d4661.png">

__В целом до__
<img width="1274" alt="coverage-before" src="https://user-images.githubusercontent.com/25789153/36668739-ea57ee02-1afa-11e8-8bac-10f10e2e705b.png">

__В целом после__
<img width="1273" alt="coverage-after" src="https://user-images.githubusercontent.com/25789153/36668748-f0618e8e-1afa-11e8-9414-066e5c93b289.png">
