### PR TITLE
fix: optional timeouts by default does not equal to httpTimeout

### DIFF
--- a/lib/browser/new-browser.js
+++ b/lib/browser/new-browser.js
@@ -38,6 +38,10 @@ module.exports = class NewBrowser extends Browser {
     }
 
     _setHttpTimeout(timeout) {
+        if (timeout === null) {
+            timeout = this._config.httpTimeout;
+        }
+
         this._session.extendOptions({connectionRetryTimeout: timeout});
     }
 

--- a/lib/config/browser-options.js
+++ b/lib/config/browser-options.js
@@ -73,7 +73,7 @@ function buildBrowserOptions(defaultFactory, extra) {
         waitTimeout: options.positiveInteger('waitTimeout'),
 
         screenshotOnReject: options.boolean('screenshotOnReject'),
-        screenshotOnRejectTimeout: options.nonNegativeInteger('screenshotOnRejectTimeout'),
+        screenshotOnRejectTimeout: options.optionalNonNegativeInteger('screenshotOnRejectTimeout'),
 
         prepareBrowser: options.optionalFunction('prepareBrowser'),
 

--- a/lib/config/defaults.js
+++ b/lib/config/defaults.js
@@ -1,7 +1,5 @@
 'use strict';
 
-const DEFAULT_HTTP_TIMEOUT = 90000;
-
 module.exports = {
     baseUrl: 'http://localhost',
     gridUrl: 'http://localhost:4444/wd/hub',
@@ -15,11 +13,11 @@ module.exports = {
     prepareBrowser: null,
     prepareEnvironment: null,
     waitTimeout: 1000,
-    httpTimeout: DEFAULT_HTTP_TIMEOUT,
-    sessionRequestTimeout: DEFAULT_HTTP_TIMEOUT,
-    sessionQuitTimeout: DEFAULT_HTTP_TIMEOUT,
+    httpTimeout: 90000,
+    sessionRequestTimeout: null,
+    sessionQuitTimeout: null,
     screenshotOnReject: true,
-    screenshotOnRejectTimeout: DEFAULT_HTTP_TIMEOUT,
+    screenshotOnRejectTimeout: null,
     reporters: ['flat'],
     debug: false,
     sessionsPerBrowser: 1,

--- a/test/lib/browser/new-browser.js
+++ b/test/lib/browser/new-browser.js
@@ -182,6 +182,14 @@ describe('NewBrowser', () => {
                 });
         });
 
+        it('should use http timeout for initializing of a session if session request timeout not set', () => {
+            return mkBrowser_({sessionRequestTimeout: null, httpTimeout: 500100})
+                .init()
+                .then(() => {
+                    assert.calledWithMatch(session.extendOptions.secondCall, {connectionRetryTimeout: 500100});
+                });
+        });
+
         it('should set option "screenshotOnReject" to "false" before initializing of a session', () => {
             return mkBrowser_()
                 .init()


### PR DESCRIPTION
sessionRequestTimeout, sessionQuitTimeout and screenshotOnRejectTimeout
for now by default equals to 90000