### PR TITLE
fix: config property "shouldRetry" now works correctly

### DIFF
--- a/README.md
+++ b/README.md
@@ -508,7 +508,7 @@ By default is `Infinity` (no limit, all tests will be run in the same session). 
 ### retry
 How many times a test should be retried if it fails. Global value for all browsers. Default value is `0`.
 
-## shouldRetry
+### shouldRetry
 Function that determines whether to make a retry. Must return boolean value. By default returns `true` if retry attempts are available otherwise returns `false`.
 Argument of this function is object with fields:
   * `retriesLeft {Number}` — number of available retries

--- a/lib/config/browser-config.js
+++ b/lib/config/browser-config.js
@@ -4,9 +4,7 @@ const path = require('path');
 const _ = require('lodash');
 
 module.exports = class BrowserConfig {
-    constructor(id, browserOptions, systemOptions) {
-        this.id = id;
-        this.system = systemOptions;
+    constructor(browserOptions) {
         _.extend(this, browserOptions);
     }
 

--- a/lib/config/browser-options.js
+++ b/lib/config/browser-options.js
@@ -66,6 +66,7 @@ function buildBrowserOptions(defaultFactory, extra) {
         testsPerSession: options.positiveIntegerOrInfinity('testsPerSession'),
 
         retry: options.nonNegativeInteger('retry'),
+        shouldRetry: options.optionalFunction('shouldRetry'),
 
         httpTimeout: options.nonNegativeInteger('httpTimeout'),
         sessionRequestTimeout: options.optionalNonNegativeInteger('sessionRequestTimeout'),

--- a/lib/config/defaults.js
+++ b/lib/config/defaults.js
@@ -27,6 +27,7 @@ module.exports = {
     workers: 1,
     testsPerWorker: Infinity,
     retry: 0,
+    shouldRetry: null,
     mochaOpts: {
         slow: 10000,
         timeout: 60000

--- a/lib/config/index.js
+++ b/lib/config/index.js
@@ -41,7 +41,15 @@ module.exports = class Config {
         }));
 
         this.browsers = _.mapValues(this.browsers, (browser, id) => {
-            return new BrowserConfig(id, browser, this.system);
+            const browserOptions = _.extend({},
+                browser,
+                {
+                    id: id,
+                    system: this.system
+                }
+            );
+
+            return new BrowserConfig(browserOptions);
         });
     }
 

--- a/test/lib/config/browser-config.js
+++ b/test/lib/config/browser-config.js
@@ -9,28 +9,24 @@ describe('BrowserConfig', () => {
 
     describe('constructor', () => {
         it('should contain a browser id', () => {
-            const config = new BrowserConfig('bro');
+            const config = new BrowserConfig({
+                id: 'bro'
+            });
 
             assert.equal(config.id, 'bro');
         });
 
         it('should be extended with passed options', () => {
-            const config = new BrowserConfig('bro', {foo: 'bar'});
+            const config = new BrowserConfig({foo: 'bar'});
 
             assert.equal(config.foo, 'bar');
-        });
-
-        it('should contain a system options', () => {
-            const config = new BrowserConfig('bro', {}, {foo: 'bar'});
-
-            assert.deepEqual(config.system, {foo: 'bar'});
         });
     });
 
     describe('getScreenshotPath', () => {
         it('should return full screenshot path for current test state', () => {
             const test = {id: () => '12345'};
-            const config = new BrowserConfig('bro', {screenshotsDir: 'scrs'});
+            const config = new BrowserConfig({id: 'bro', screenshotsDir: 'scrs'});
             sandbox.stub(process, 'cwd').returns('/def/path');
 
             const res = config.getScreenshotPath(test, 'plain');
@@ -39,7 +35,7 @@ describe('BrowserConfig', () => {
         });
 
         it('should override screenshot path with result of "screenshotsDir" execution if it is function', () => {
-            const config = new BrowserConfig('bro', {screenshotsDir: () => '/foo'});
+            const config = new BrowserConfig({screenshotsDir: () => '/foo'});
             const res = config.getScreenshotPath({}, 'plain');
 
             assert.equal(res, '/foo/plain.png');
@@ -48,7 +44,7 @@ describe('BrowserConfig', () => {
 
     describe('serialize', () => {
         it('should serialize all props except system options', () => {
-            const config = new BrowserConfig('bro', {foo: 'bar'}, {baz: 'qux'});
+            const config = new BrowserConfig({id: 'bro', foo: 'bar', system: {baz: 'qux'}});
 
             const result = config.serialize();
 

--- a/test/lib/config/options.js
+++ b/test/lib/config/options.js
@@ -313,4 +313,30 @@ describe('config options', () => {
             );
         });
     });
+
+    describe('shouldRetry', () => {
+        it('should throw error if shouldRetry is not a function', () => {
+            const readConfig = _.set({}, 'shouldRetry', 'shouldRetry');
+
+            Config.read.returns(readConfig);
+
+            assert.throws(() => createConfig(), Error, '"shouldRetry" must be a function');
+        });
+
+        it('should set default shouldRetry option if it does not set in config file', () => {
+            const config = createConfig();
+
+            assert.equal(config.shouldRetry, null);
+        });
+
+        it('should override shouldRetry option', () => {
+            const shouldRetry = () => {};
+            const readConfig = _.set({}, 'shouldRetry', shouldRetry);
+            Config.read.returns(readConfig);
+
+            const config = createConfig();
+
+            assert.equal(config.shouldRetry, shouldRetry);
+        });
+    });
 });


### PR DESCRIPTION
Патч для https://github.com/gemini-testing/hermione/issues/246

* Из конфига теперь считывается свойство shouldRetry
* Добавлены тесты на shouldRetry
* Изменен конструктор BrowserConfig и поправлены тесты.
* Поправлено README.md