### PR TITLE
feat: AFTER_TESTS_READ event

### DIFF
--- a/README.md
+++ b/README.md
@@ -638,6 +638,7 @@ Event                     | Description
 `INIT`                    | Will be triggered before any job start (`run` or `readTests`). If handler returns a promise then job will start only after the promise will be resolved. Emitted only once no matter how many times job will be performed.
 `BEFORE_FILE_READ`        | Will be triggered on test files parsing before reading the file. The handler accepts data object with `file`, `browser` (browser id string), `hermione` (helper which will be available in test file) and !!DEPRECATED!! `suite` (collection of tests in a file; provides the ability to subscribe on `test` and `suite` events) fields.
 `AFTER_FILE_READ`         | Will be triggered on test files parsing right after reading the file. The handler accepts data object with `file`, `browser` (browser id string), `hermione` (helper which will be available in test file) and !!DEPRECATED!! `suite` (collection of tests in a file; provides the ability to subscribe on `test` and `suite` events) fields.
+`AFTER_TESTS_READ`        | Will be triggered right after tests read via `readTests` or `run` methods with `TestCollection` object.
 `RUNNER_START`            | Will be triggered before test execution. If a handler returns a promise, tests will be executed only after the promise is resolved. The handler accepts an instance of a runner as the first argument. You can use this instance to emit and subscribe to any other available events.
 `RUNNER_END`              | Will be triggered after test execution. If a handler returns a promise, tests will be executed only after the promise is resolved. The handler accepts a stats of tests execution.
 `SESSION_START`           | Will be triggered after browser session initialization. If a handler returns a promise, tests will be executed only after the promise is resolved. The handler accepts an instance of webdriverIO as the first argument and an object with a browser identifier as the second.
@@ -662,6 +663,7 @@ Event                     | Description
 ------------------------- | -------------
 `BEFORE_FILE_READ`        | Will be triggered on test files parsing before reading the file. The handler accepts data object with `file`, `browser` (browser id string), `hermione` (helper which will be available in test file) and `suite` (collection of tests in a file; provides the ability to subscribe on `test` and `suite` events) fields.
 `AFTER_FILE_READ`         | Will be triggered on test files parsing right after reading the file. The handler accepts data object with `file`, `browser` (browser id string), `hermione` (helper which will be available in test file) and `suite` (collection of tests in a file; provides the ability to subscribe on `test` and `suite` events) fields.
+`AFTER_TESTS_READ`        | Will be triggered right after tests read each time some file is being reading during test run.
 `NEW_BROWSER`             | Will be triggered after new browser instance created. The handler accepts an instance of webdriverIO as the first argument and an object with a browser identifier as the second.
 
 **REMARK!**

--- a/lib/constants/runner-events.js
+++ b/lib/constants/runner-events.js
@@ -22,6 +22,8 @@ const getSyncEvents = () => ({
     BEFORE_FILE_READ: 'beforeFileRead',
     AFTER_FILE_READ: 'afterFileRead',
 
+    AFTER_TESTS_READ: 'afterTestsRead',
+
     SUITE_BEGIN: 'beginSuite',
     SUITE_END: 'endSuite',
 

--- a/lib/hermione.js
+++ b/lib/hermione.js
@@ -63,8 +63,13 @@ module.exports = class Hermione extends BaseHermione {
         }
 
         const specs = await testReader.read({paths: testPaths, browsers, ignore, sets, grep});
+        const collection = TestCollection.create(specs);
 
-        return TestCollection.create(specs);
+        if (!silent) {
+            this.emit(RunnerEvents.AFTER_TESTS_READ, collection);
+        }
+
+        return collection;
     }
 
     isFailed() {

--- a/lib/worker/constants/runner-events.js
+++ b/lib/worker/constants/runner-events.js
@@ -8,6 +8,8 @@ module.exports = {
     BEFORE_FILE_READ: MainProcessRunnerEvents.BEFORE_FILE_READ,
     AFTER_FILE_READ: MainProcessRunnerEvents.AFTER_FILE_READ,
 
+    AFTER_TESTS_READ: MainProcessRunnerEvents.AFTER_TESTS_READ,
+
     TEST_FAIL: MainProcessRunnerEvents.TEST_FAIL,
     ERROR: MainProcessRunnerEvents.ERROR,
 

--- a/lib/worker/hermione.js
+++ b/lib/worker/hermione.js
@@ -5,6 +5,7 @@ const eventsUtils = require('gemini-core').events.utils;
 const RunnerEvents = require('./constants/runner-events');
 const Runner = require('./runner');
 const BaseHermione = require('../base-hermione');
+const TestCollection = require('../test-collection');
 
 module.exports = class Hermione extends BaseHermione {
     constructor(configPath) {
@@ -18,6 +19,13 @@ module.exports = class Hermione extends BaseHermione {
 
             RunnerEvents.NEW_BROWSER
         ]);
+
+        this._runner.on(RunnerEvents.AFTER_FILE_READ, (data) => {
+            const tests = [];
+            data.suite.eachTest((t) => tests.push(t));
+
+            this.emit(RunnerEvents.AFTER_TESTS_READ, TestCollection.create({[data.browser]: tests}));
+        });
     }
 
     init() {

--- a/test/lib/hermione.js
+++ b/test/lib/hermione.js
@@ -558,6 +558,38 @@ describe('hermione', () => {
                 assert.calledOnce(onInit);
             });
         });
+
+        describe('AFTER_TESTS_READ', () => {
+            it('should emit AFTER_TESTS_READ on read', async () => {
+                const onAfterTestsRead = sinon.spy();
+                const hermione = Hermione.create()
+                    .on(RunnerEvents.AFTER_TESTS_READ, onAfterTestsRead);
+
+                await hermione.readTests();
+
+                assert.calledOnce(onAfterTestsRead);
+            });
+
+            it('should pass test collection with AFTER_TESTS_READ event', async () => {
+                const onAfterTestsRead = sinon.spy();
+                const hermione = Hermione.create()
+                    .on(RunnerEvents.AFTER_TESTS_READ, onAfterTestsRead);
+
+                const collection = await hermione.readTests();
+
+                assert.calledWith(onAfterTestsRead, collection);
+            });
+
+            it('should not emit AFTER_TESTS_READ in silent mode', async () => {
+                const onAfterTestsRead = sinon.spy();
+                const hermione = Hermione.create()
+                    .on(RunnerEvents.AFTER_TESTS_READ, onAfterTestsRead);
+
+                await hermione.readTests(null, {silent: true});
+
+                assert.notCalled(onAfterTestsRead);
+            });
+        });
     });
 
     describe('should provide access to', () => {

--- a/test/utils.js
+++ b/test/utils.js
@@ -57,7 +57,8 @@ function makeSuite(opts = {}) {
         id: () => 'default-id',
         parent: {root: true},
         title: 'default-suite',
-        fullTitle: () => 'default-suite'
+        fullTitle: () => 'default-suite',
+        eachTest: () => {}
     });
 }
 


### PR DESCRIPTION
Это событие нужно, чтобы перевести на него плагины, использующие `BEFORE_FILE_READ` и `AFTER_FILE_READ` для модификации дерева тестов.
В воркере пока кидается вместе с `AFTER_FILE_READ` на каждый тест, в следующих PR'ах в воркерах будут разделены парсер и раннер, и событие скорее всего будет лететь на каждый файл.