### PR TITLE
fix: .only does not work for all browsers

### DIFF
--- a/lib/test-reader/index.js
+++ b/lib/test-reader/index.js
@@ -32,10 +32,14 @@ module.exports = class TestReader extends EventEmitter {
 
         const filesByBro = setCollection.groupByBrowser();
 
-        return _.mapValues(filesByBro, (files, browserId) => this._parseBrowserTests(files, browserId, grep));
+        return _(filesByBro)
+            .mapValues((files, browserId) => ({parser: this._makeParser(browserId, grep), files}))
+            .mapValues(({parser, files}) => parser.loadFiles(files))
+            .mapValues((parser) => parser.parse())
+            .value();
     }
 
-    _parseBrowserTests(files, browserId, grep) {
+    _makeParser(browserId, grep) {
         const parser = TestParser.create(browserId, this._config.system);
 
         passthroughEvent(parser, this, [
@@ -45,8 +49,6 @@ module.exports = class TestReader extends EventEmitter {
 
         return parser
             .applySkip(this._testSkipper)
-            .applyGrep(grep)
-            .loadFiles(files)
-            .parse();
+            .applyGrep(grep);
     }
 };


### PR DESCRIPTION
`.only` на самом деле выставляет grep.
В итоге логика была такая:
- парсим тесты для первого браузера, там нет .only - грепа нет
- применяем греп для дерева первого браузера, его нет, читаем все тесты
- парсим тесты для второго, там .only - он записывается в греп
- применяем греп для дерева второго браузера, но первое дерево уже распаршено

Теперь сначала создаем все парсеры, потом всем парсерам выставляем grep, затем парсим все деревья, затем для всех деревьев применяем grep