### PR TITLE
Avoid hermioneCtx sharing between different test runs

### DIFF
--- a/lib/worker/runner/test-runner/index.js
+++ b/lib/worker/runner/test-runner/index.js
@@ -13,7 +13,13 @@ module.exports = class TestRunner {
     }
 
     constructor(test, config, browserAgent) {
-        this._test = Object.create(test);
+        this._test = _.cloneDeepWith(test, (val, key) => {
+            // Don't clone whole tree
+            if (key === 'parent') {
+                return val;
+            }
+        });
+
         this._config = config;
         this._browserAgent = browserAgent;
     }
@@ -24,7 +30,8 @@ module.exports = class TestRunner {
 
         const screenshooter = OneTimeScreenshooter.create(this._config, browser);
 
-        const hermioneCtx = test.hermioneCtx ? _.cloneDeep(test.hermioneCtx) : {};
+        const hermioneCtx = test.hermioneCtx || {};
+
         const executionThread = ExecutionThread.create({test, browser, hermioneCtx, screenshooter});
         const hookRunner = HookRunner.create(test, executionThread);
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -93,7 +93,7 @@
     },
     "acorn": {
       "version": "1.2.2",
-      "resolved": "http://registry.npmjs.org/acorn/-/acorn-1.2.2.tgz",
+      "resolved": "https://registry.npmjs.org/acorn/-/acorn-1.2.2.tgz",
       "integrity": "sha1-yM4n3grMdtiW0rH6099YjZ6C8BQ="
     },
     "acorn-jsx": {
@@ -637,7 +637,7 @@
     },
     "browserify": {
       "version": "13.3.0",
-      "resolved": "http://registry.npmjs.org/browserify/-/browserify-13.3.0.tgz",
+      "resolved": "https://registry.npmjs.org/browserify/-/browserify-13.3.0.tgz",
       "integrity": "sha1-tanJAgJD8McORnW+yCI7xifkFc4=",
       "requires": {
         "JSONStream": "^1.0.3",
@@ -691,7 +691,7 @@
       "dependencies": {
         "buffer": {
           "version": "4.9.1",
-          "resolved": "http://registry.npmjs.org/buffer/-/buffer-4.9.1.tgz",
+          "resolved": "https://registry.npmjs.org/buffer/-/buffer-4.9.1.tgz",
           "integrity": "sha1-bRu2AbB6TvztlwlBMgkwJ8lbwpg=",
           "requires": {
             "base64-js": "^1.0.2",
@@ -708,7 +708,7 @@
     },
     "browserify-aes": {
       "version": "1.2.0",
-      "resolved": "http://registry.npmjs.org/browserify-aes/-/browserify-aes-1.2.0.tgz",
+      "resolved": "https://registry.npmjs.org/browserify-aes/-/browserify-aes-1.2.0.tgz",
       "integrity": "sha512-+7CHXqGuspUn/Sl5aO7Ea0xWGAtETPXNSAjHo48JfLdPWcMng33Xe4znFvQweqc/uzk5zSOI3H52CYnjCfb5hA==",
       "requires": {
         "buffer-xor": "^1.0.3",
@@ -742,7 +742,7 @@
     },
     "browserify-rsa": {
       "version": "4.0.1",
-      "resolved": "http://registry.npmjs.org/browserify-rsa/-/browserify-rsa-4.0.1.tgz",
+      "resolved": "https://registry.npmjs.org/browserify-rsa/-/browserify-rsa-4.0.1.tgz",
       "integrity": "sha1-IeCr+vbyApzy+vsTNWenAdQTVSQ=",
       "requires": {
         "bn.js": "^4.1.0",
@@ -1921,7 +1921,7 @@
     },
     "convert-source-map": {
       "version": "1.1.3",
-      "resolved": "http://registry.npmjs.org/convert-source-map/-/convert-source-map-1.1.3.tgz",
+      "resolved": "https://registry.npmjs.org/convert-source-map/-/convert-source-map-1.1.3.tgz",
       "integrity": "sha1-SCnId+n+SbMWHzvzZziI4gRpmGA="
     },
     "copy-descriptor": {
@@ -1967,7 +1967,7 @@
     },
     "create-hash": {
       "version": "1.2.0",
-      "resolved": "http://registry.npmjs.org/create-hash/-/create-hash-1.2.0.tgz",
+      "resolved": "https://registry.npmjs.org/create-hash/-/create-hash-1.2.0.tgz",
       "integrity": "sha512-z00bCGNHDG8mHAkP7CtT1qVu+bFQUPjYq/4Iv3C3kWjTFV10zIjfSoeqXo9Asws8gwSHDGj/hl2u4OGIjapeCg==",
       "requires": {
         "cipher-base": "^1.0.1",
@@ -1979,7 +1979,7 @@
     },
     "create-hmac": {
       "version": "1.1.7",
-      "resolved": "http://registry.npmjs.org/create-hmac/-/create-hmac-1.1.7.tgz",
+      "resolved": "https://registry.npmjs.org/create-hmac/-/create-hmac-1.1.7.tgz",
       "integrity": "sha512-MJG9liiZ+ogc4TzUwuvbER1JRdgvUFSB5+VR/g5h82fGaIRWMWddtKBHi7/sVhfjQZ6SehlyhvQYrcYkaUIpLg==",
       "requires": {
         "cipher-base": "^1.0.3",
@@ -2260,7 +2260,7 @@
     },
     "diffie-hellman": {
       "version": "5.0.3",
-      "resolved": "http://registry.npmjs.org/diffie-hellman/-/diffie-hellman-5.0.3.tgz",
+      "resolved": "https://registry.npmjs.org/diffie-hellman/-/diffie-hellman-5.0.3.tgz",
       "integrity": "sha512-kqag/Nl+f3GwyK25fhUMYj81BUOrZ9IuJsjIcDE5icNM9FJHAVm3VcUDxdLPoQtTuUylWm6ZIknYJwwaPxsUzg==",
       "requires": {
         "bn.js": "^4.1.0",
@@ -2805,7 +2805,7 @@
     },
     "events": {
       "version": "1.1.1",
-      "resolved": "http://registry.npmjs.org/events/-/events-1.1.1.tgz",
+      "resolved": "https://registry.npmjs.org/events/-/events-1.1.1.tgz",
       "integrity": "sha1-nr23Y1rQmccNzEwqH1AEKI6L2SQ="
     },
     "evp_bytestokey": {
@@ -5356,7 +5356,7 @@
     },
     "parse-asn1": {
       "version": "5.1.1",
-      "resolved": "http://registry.npmjs.org/parse-asn1/-/parse-asn1-5.1.1.tgz",
+      "resolved": "https://registry.npmjs.org/parse-asn1/-/parse-asn1-5.1.1.tgz",
       "integrity": "sha512-KPx7flKXg775zZpnp9SxJlz00gTd4BmJ2yJufSc44gMCRrRQ7NSzAcSJQfifuOLgW6bEi+ftrALtsgALeB2Adw==",
       "requires": {
         "asn1.js": "^4.0.0",
@@ -6146,7 +6146,7 @@
     },
     "sha.js": {
       "version": "2.4.11",
-      "resolved": "http://registry.npmjs.org/sha.js/-/sha.js-2.4.11.tgz",
+      "resolved": "https://registry.npmjs.org/sha.js/-/sha.js-2.4.11.tgz",
       "integrity": "sha512-QMEp5B7cftE7APOjk5Y6xgrbWu+WkLVQwk8JNjZ8nKRciZaByEW6MubieAiToS7+dwvrjGhH8jRXz3MVd0AYqQ==",
       "requires": {
         "inherits": "^2.0.1",
@@ -6155,7 +6155,7 @@
     },
     "shasum": {
       "version": "1.0.2",
-      "resolved": "http://registry.npmjs.org/shasum/-/shasum-1.0.2.tgz",
+      "resolved": "https://registry.npmjs.org/shasum/-/shasum-1.0.2.tgz",
       "integrity": "sha1-5wEjENj0F/TetXEhUOVni4euVl8=",
       "requires": {
         "json-stable-stringify": "~0.0.0",
@@ -6710,7 +6710,7 @@
       "dependencies": {
         "minimist": {
           "version": "1.2.0",
-          "resolved": "http://registry.npmjs.org/minimist/-/minimist-1.2.0.tgz",
+          "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.0.tgz",
           "integrity": "sha1-o1AIsg9BOD7sH7kU9M1d95omQoQ="
         }
       }

--- a/test/lib/worker/runner/test-runner/index.js
+++ b/test/lib/worker/runner/test-runner/index.js
@@ -134,9 +134,10 @@ describe('worker/runner/test-runner', () => {
         });
 
         it('test hermioneCtx should be protected from modification during run', async () => {
-            ExecutionThread.create.callsFake(({hermioneCtx}) => {
+            ExecutionThread.create.callsFake(({test, hermioneCtx}) => {
                 ExecutionThread.prototype.run.callsFake(() => {
                     hermioneCtx.baz = 'qux';
+                    test.hermioneCtx.baaz = 'quux';
                 });
 
                 return Object.create(ExecutionThread.prototype);
@@ -148,6 +149,22 @@ describe('worker/runner/test-runner', () => {
             await run_({test});
 
             assert.deepEqual(test.hermioneCtx, {foo: 'bar'});
+        });
+
+        it('test parent should be shared between runs', async () => {
+            ExecutionThread.create.callsFake(({test}) => {
+                ExecutionThread.prototype.run.callsFake(() => {
+                    test.parent.foo = 'bar';
+                });
+
+                return Object.create(ExecutionThread.prototype);
+            });
+
+            const test = mkTest_();
+
+            await run_({test});
+
+            assert.propertyVal(test.parent, 'foo', 'bar');
         });
 
         it('should create execution thread with screenshooter', async () => {


### PR DESCRIPTION
Контекст:
- объект `test` создается один раз при чтении тестов, затем кэшируется.
Для того, чтобы во время запуска тестов не модифицировался оригинальный объект `test` в `TestRunner`'е создается объект `_test`, которому в прототип записывается `test`
- во время выполнения хуков и тестов создается новый объект `hermioneCtx`, который доступен через `session.executionContext.hermioneCtx`, и который является клном оригинального `test.hermioneCtx`

Проблема: если доступ к `hermioneCtx` осуществляется через `session.executionContext.ctx.currentTest.hermioneCtx`, то модифицируется оригинальный `test.hermioneCtx`, в итоге:
- тесты не падают с ошибками `assertView`, т.к. модифицируется оригинальный `test.hermioneCtx`,  а проверяется склонированный
- результаты `assertView` записываются в `test.hermioneCtx` навсегда, и все следующие ретраи этого теста в этом воркере запускаются уже с этими результатами
