### PR TITLE
feat: add image sizes to assertViewResults

### DIFF
--- a/lib/browser/commands/assert-view/capture-processors/assert-refs.js
+++ b/lib/browser/commands/assert-view/capture-processors/assert-refs.js
@@ -4,14 +4,14 @@ const Promise = require('bluebird');
 const ImageDiffError = require('../errors/image-diff-error');
 const NoRefImageError = require('../errors/no-ref-image-error');
 
-exports.handleNoRefImage = (currPath, refPath, state) => {
-    return Promise.reject(new NoRefImageError(state, currPath, refPath));
+exports.handleNoRefImage = (currImg, refImg, state) => {
+    return Promise.reject(NoRefImageError.create(state, currImg, refImg));
 };
 
-exports.handleImageDiff = (currPath, refPath, state, config) => {
+exports.handleImageDiff = (currImg, refImg, state, config) => {
     const {tolerance} = config;
     const {system: {diffColor}} = config;
 
-    const diffOpts = {reference: refPath, current: currPath, diffColor, tolerance};
-    return Promise.reject(new ImageDiffError(state, currPath, refPath, diffOpts));
+    const diffOpts = {current: currImg.path, reference: refImg.path, diffColor, tolerance};
+    return Promise.reject(ImageDiffError.create(state, currImg, refImg, diffOpts));
 };

--- a/lib/browser/commands/assert-view/capture-processors/update-refs.js
+++ b/lib/browser/commands/assert-view/capture-processors/update-refs.js
@@ -2,4 +2,4 @@
 
 const fs = require('fs-extra');
 
-exports.handleNoRefImage = exports.handleImageDiff = (currPath, refPath) => fs.copy(currPath, refPath);
+exports.handleNoRefImage = exports.handleImageDiff = (currImg, refImg) => fs.copy(currImg.path, refImg.path);

--- a/lib/browser/commands/assert-view/errors/base-state-error.js
+++ b/lib/browser/commands/assert-view/errors/base-state-error.js
@@ -1,12 +1,12 @@
 'use strict';
 
 module.exports = class BaseStateError extends Error {
-    constructor(stateName, currentImagePath, refImagePath) {
+    constructor(stateName, currImg = {}, refImg = {}) {
         super();
 
         this.name = this.constructor.name;
         this.stateName = stateName;
-        this.currentImagePath = currentImagePath;
-        this.refImagePath = refImagePath;
+        this.currImg = currImg;
+        this.refImg = refImg;
     }
 };

--- a/lib/browser/commands/assert-view/errors/image-diff-error.js
+++ b/lib/browser/commands/assert-view/errors/image-diff-error.js
@@ -4,12 +4,16 @@ const {Image} = require('gemini-core');
 const BaseStateError = require('./base-state-error');
 
 module.exports = class ImageDiffError extends BaseStateError {
-    static fromObject(data) {
-        return new ImageDiffError(data.stateName, data.currentImagePath, data.refImagePath, data.diffOpts);
+    static create(...args) {
+        return new this(...args);
     }
 
-    constructor(stateName, currentPath, refImagePath, diffOpts) {
-        super(stateName, currentPath, refImagePath);
+    static fromObject(data) {
+        return new ImageDiffError(data.stateName, data.currImg, data.refImg, data.diffOpts);
+    }
+
+    constructor(stateName, currImg, refImg, diffOpts) {
+        super(stateName, currImg, refImg);
 
         this.message = `images are different for "${stateName}" state`;
         this.diffOpts = diffOpts;

--- a/lib/browser/commands/assert-view/errors/no-ref-image-error.js
+++ b/lib/browser/commands/assert-view/errors/no-ref-image-error.js
@@ -3,13 +3,17 @@
 const BaseSateError = require('./base-state-error');
 
 module.exports = class NoRefImageError extends BaseSateError {
-    static fromObject(data) {
-        return new NoRefImageError(data.stateName, data.currentImagePath, data.refImagePath);
+    static create(...args) {
+        return new this(...args);
     }
 
-    constructor(stateName, currPath, refPath) {
-        super(stateName, currPath, refPath);
+    static fromObject(data) {
+        return new NoRefImageError(data.stateName, data.currImg, data.refImg);
+    }
 
-        this.message = `can not find reference image at ${refPath} for "${stateName}" state`;
+    constructor(stateName, currImg, refImg) {
+        super(stateName, currImg, refImg);
+
+        this.message = `can not find reference image at ${this.refImg.path} for "${stateName}" state`;
     }
 };

--- a/lib/browser/commands/assert-view/index.js
+++ b/lib/browser/commands/assert-view/index.js
@@ -1,6 +1,6 @@
 'use strict';
 
-const fs = require('fs');
+const fs = require('fs-extra');
 const _ = require('lodash');
 const {Image, temp, ScreenShooter} = require('gemini-core');
 const {getCaptureProcessors} = require('./capture-processors');
@@ -20,12 +20,6 @@ module.exports = (browser) => {
         opts = _.defaults(opts, {ignoreElements: []});
 
         const test = getTestContext(session.executionContext);
-        const refPath = config.getScreenshotPath(test, state);
-        const tempOpts = RuntimeConfig.getInstance().tempOpts;
-
-        temp.attach(tempOpts);
-        const currPath = temp.path(Object.assign(tempOpts, {suffix: '.png'}));
-
         test.hermioneCtx.assertViewResults = test.hermioneCtx.assertViewResults || AssertViewResults.create();
 
         const handleCaptureProcessorError = (e) => e instanceof BaseStateError
@@ -35,22 +29,31 @@ module.exports = (browser) => {
         const page = await browser.prepareScreenshot(
             [].concat(selectors), {ignoreSelectors: [].concat(opts.ignoreElements)}
         );
-        const currImage = await screenShooter.capture(page);
 
-        await currImage.save(currPath);
+        const {tempOpts} = RuntimeConfig.getInstance();
+        temp.attach(tempOpts);
 
-        if (!fs.existsSync(refPath)) {
-            return handleNoRefImage(currPath, refPath, state).catch((e) => handleCaptureProcessorError(e));
+        const currImgInst = await screenShooter.capture(page);
+        const currImg = {path: temp.path(Object.assign(tempOpts, {suffix: '.png'})), size: currImgInst.getSize()};
+        await currImgInst.save(currImg.path);
+
+        const refImg = {path: config.getScreenshotPath(test, state), size: null};
+
+        if (!fs.existsSync(refImg.path)) {
+            return handleNoRefImage(currImg, refImg, state).catch((e) => handleCaptureProcessorError(e));
         }
+
+        const refImgBase64 = fs.readFileSync(refImg.path);
+        refImg.size = Image.fromBase64(refImgBase64).getSize();
 
         const {canHaveCaret, pixelRatio} = page;
         const compareOpts = {tolerance, antialiasingTolerance, canHaveCaret, pixelRatio};
-        const isEqual = await Image.compare(refPath, currPath, compareOpts);
+        const isEqual = await Image.compare(refImg.path, currImg.path, compareOpts);
 
         if (!isEqual) {
-            return handleImageDiff(currPath, refPath, state, config).catch((e) => handleCaptureProcessorError(e));
+            return handleImageDiff(currImg, refImg, state, config).catch((e) => handleCaptureProcessorError(e));
         }
 
-        test.hermioneCtx.assertViewResults.add({stateName: state, refImagePath: refPath});
+        test.hermioneCtx.assertViewResults.add({stateName: state, refImg: refImg});
     });
 };

--- a/lib/browser/commands/assert-view/index.js
+++ b/lib/browser/commands/assert-view/index.js
@@ -16,7 +16,7 @@ module.exports = (browser) => {
 
     const {handleNoRefImage, handleImageDiff} = getCaptureProcessors();
 
-    session.addCommand('assertView', (state, selectors, opts = {}) => {
+    session.addCommand('assertView', async (state, selectors, opts = {}) => {
         opts = _.defaults(opts, {ignoreElements: []});
 
         const test = getTestContext(session.executionContext);
@@ -28,29 +28,29 @@ module.exports = (browser) => {
 
         test.hermioneCtx.assertViewResults = test.hermioneCtx.assertViewResults || AssertViewResults.create();
 
-        const handleCaptureProcessorError = (e) => e instanceof BaseStateError ? test.hermioneCtx.assertViewResults.add(e) : Promise.reject(e);
+        const handleCaptureProcessorError = (e) => e instanceof BaseStateError
+            ? test.hermioneCtx.assertViewResults.add(e)
+            : Promise.reject(e);
 
-        return browser.prepareScreenshot([].concat(selectors), {ignoreSelectors: [].concat(opts.ignoreElements)})
-            .then((page) => {
-                return screenShooter.capture(page)
-                    .then((currImage) => currImage.save(currPath))
-                    .then(() => {
-                        if (!fs.existsSync(refPath)) {
-                            return handleNoRefImage(currPath, refPath, state).catch((e) => handleCaptureProcessorError(e));
-                        }
+        const page = await browser.prepareScreenshot(
+            [].concat(selectors), {ignoreSelectors: [].concat(opts.ignoreElements)}
+        );
+        const currImage = await screenShooter.capture(page);
 
-                        const {canHaveCaret, pixelRatio} = page;
-                        const compareOpts = {tolerance, antialiasingTolerance, canHaveCaret, pixelRatio};
+        await currImage.save(currPath);
 
-                        return Image.compare(refPath, currPath, compareOpts)
-                            .then((isEqual) => {
-                                if (!isEqual) {
-                                    return handleImageDiff(currPath, refPath, state, config).catch((e) => handleCaptureProcessorError(e));
-                                }
+        if (!fs.existsSync(refPath)) {
+            return handleNoRefImage(currPath, refPath, state).catch((e) => handleCaptureProcessorError(e));
+        }
 
-                                test.hermioneCtx.assertViewResults.add({stateName: state, refImagePath: refPath});
-                            });
-                    });
-            });
+        const {canHaveCaret, pixelRatio} = page;
+        const compareOpts = {tolerance, antialiasingTolerance, canHaveCaret, pixelRatio};
+        const isEqual = await Image.compare(refPath, currPath, compareOpts);
+
+        if (!isEqual) {
+            return handleImageDiff(currPath, refPath, state, config).catch((e) => handleCaptureProcessorError(e));
+        }
+
+        test.hermioneCtx.assertViewResults.add({stateName: state, refImagePath: refPath});
     });
 };

--- a/lib/worker/runner/test-runner/one-time-screenshooter.js
+++ b/lib/worker/runner/test-runner/one-time-screenshooter.js
@@ -1,6 +1,7 @@
 'use strict';
 
 const _ = require('lodash');
+const {Image} = require('gemini-core');
 const logger = require('../../../utils/logger');
 
 module.exports = class OneTimeScreenshooter {
@@ -23,8 +24,10 @@ module.exports = class OneTimeScreenshooter {
         this._browser.setHttpTimeout(this._config.screenshotOnRejectTimeout);
 
         try {
-            const {value: screenshot} = await this._browser.publicAPI.screenshot();
-            error = _.extend(error, {screenshot});
+            const {value: base64} = await this._browser.publicAPI.screenshot();
+            const size = Image.fromBase64(base64).getSize();
+
+            error = _.extend(error, {screenshot: {base64, size}});
         } catch (e) {
             logger.warn(`WARN: Failed to take screenshot on reject: ${e}`);
         }

--- a/test/lib/browser/commands/assert-view/errors/no-ref-image-error.js
+++ b/test/lib/browser/commands/assert-view/errors/no-ref-image-error.js
@@ -1,39 +1,64 @@
 'use strict';
 
+const _ = require('lodash');
 const BaseStateError = require('lib/browser/commands/assert-view/errors/base-state-error');
 const NoRefImageError = require('lib/browser/commands/assert-view/errors/no-ref-image-error');
 
+const mkNoRefImageError = (opts = {}) => {
+    const {stateName, currImg, refImg} = _.defaults(opts, {
+        stateName: 'default-name',
+        currImg: {path: '/default-curr/path'},
+        refImg: {path: '/default-ref/path'}
+    });
+
+    return new NoRefImageError(stateName, currImg, refImg);
+};
+
 describe('NoRefImageError', () => {
     it('should be an instance of "BaseStateError"', () => {
-        assert.instanceOf(new NoRefImageError(), BaseStateError);
+        assert.instanceOf(mkNoRefImageError(), BaseStateError);
     });
 
     it('should be eventually an instance of Error', () => {
-        assert.instanceOf(new NoRefImageError(), Error);
+        assert.instanceOf(mkNoRefImageError(), Error);
     });
 
     it('should contain a state name', () => {
-        const error = new NoRefImageError('plain');
+        const error = mkNoRefImageError({stateName: 'plain'});
 
         assert.equal(error.stateName, 'plain');
     });
 
-    it('should contain a current image path', () => {
-        const error = new NoRefImageError('', '/curr/path');
+    it('should contain a current image', () => {
+        const error = mkNoRefImageError({currImg: {path: '/curr/path'}});
 
-        assert.equal(error.currentImagePath, '/curr/path');
+        assert.deepEqual(error.currImg, {path: '/curr/path'});
+    });
+
+    it('should contain a reference image', () => {
+        const error = mkNoRefImageError({refImg: {path: '/ref/path'}});
+
+        assert.deepEqual(error.refImg, {path: '/ref/path'});
     });
 
     it('should contain state name and reference image path in an error message', () => {
-        const error = new NoRefImageError('plain', '', 'refPath');
+        const error = mkNoRefImageError({stateName: 'plain', refImg: {path: '/ref/path'}});
 
-        assert.match(error.message, /reference image at refPath for "plain" state/);
+        assert.match(error.message, /reference image at \/ref\/path for "plain" state/);
     });
 
     it('should create an instance of error from object', () => {
-        const error = NoRefImageError.fromObject({stateName: 'name', currentImagePath: 'curr/path', refImagePath: 'ref/path'});
+        const error = NoRefImageError.fromObject({
+            stateName: 'name',
+            currImg: {path: '/curr/path'},
+            refImg: {path: '/ref/path'}
+        });
 
         assert.instanceOf(error, NoRefImageError);
-        assert.deepInclude(Object.assign({}, error), {stateName: 'name', currentImagePath: 'curr/path', refImagePath: 'ref/path'});
+        assert.deepInclude(Object.assign({}, error), {
+            stateName: 'name',
+            currImg: {path: '/curr/path'},
+            refImg: {path: '/ref/path'}
+        });
     });
 });


### PR DESCRIPTION
Эти размеры нужны для более правильно работы ленивой подзагрузки изображений в html-reporter. Для компоненты `react-lazyload` будем выставлять `height` изображения, при этом на страницу будет подставляться плейсхолдер таких же размеров пока картинка не загрузилась. С помощью данного плейсхолдера пропадет баг с постоянно дергающемся экраном когда скроллишь страницу.

Дока про `height` в react-lazyload - https://github.com/jasonslyvia/react-lazyload/tree/master/#height