### PR TITLE
feat: implement events interceptor API for plugins

### DIFF
--- a/README.md
+++ b/README.md
@@ -750,6 +750,58 @@ module.exports = (hermione, opts) => {
 };
 ```
 
+Besides, you have the ability to intercept events in plugins and translate them to other events:
+
+```js
+module.exports = (hermione) => {
+    hermione.intercept(hermione.events.TEST_FAIL, ({event, data}) => {
+        const test = Object.create(data);
+        test.pending = true;
+        test.skipReason = 'intercepted failure';
+
+        return {event: hermione.events.TEST_PENDING, data: test};
+    });
+
+    hermione.on(hermione.events.TEST_FAIL, (test) => {
+        // this event handler will never be called
+    });
+
+    hermione.on(hermione.evenst.TEST_PENDING, (test) => {
+        // this event handler will always be called instead of 'TEST_FAIL' one
+    });
+};
+```
+
+If for some reason interceptor should not translate passed event to another one you can return the same object or some falsey value:
+
+```js
+module.exports = (hermione) => {
+    hermione.intercept(hermione.events.TEST_FAIL, ({event, data}) => {
+        return {event, data};
+        // return;
+        // return null;
+        // return false;
+    });
+
+    hermione.on(hermione.events.TEST_FAIL, (test) => {
+        // this event handler will be called as usual because interceptor does not change event
+    });
+};
+```
+
+**Available events which can be intercepted**
+
+Event                     |
+------------------------- |
+`SUITE_BEGIN`             |
+`SUITE_END`               |
+`TEST_BEGIN`              |
+`TEST_END`                |
+`TEST_PASS`               |
+`TEST_FAIL`               |
+`RETRY`                   |
+
+
 ### prepareBrowser
 Prepare the browser session before tests are run. For example, add custom user commands.
 ```js

--- a/lib/base-hermione.js
+++ b/lib/base-hermione.js
@@ -20,6 +20,8 @@ module.exports = class BaseHermione extends AsyncEmitter {
     constructor(configPath) {
         super();
 
+        this._interceptors = [];
+
         this._config = Config.create(configPath);
         this._loadPlugins();
     }
@@ -39,6 +41,12 @@ module.exports = class BaseHermione extends AsyncEmitter {
 
     get errors() {
         return Errors;
+    }
+
+    intercept(event, handler) {
+        this._interceptors.push({event, handler});
+
+        return this;
     }
 
     isWorker() {

--- a/lib/constants/runner-events.js
+++ b/lib/constants/runner-events.js
@@ -1,3 +1,4 @@
+// TODO: refactor this file because it contains not only runner events
 'use strict';
 
 const _ = require('lodash');
@@ -16,14 +17,7 @@ const getAsyncEvents = () => ({
     EXIT: 'exit'
 });
 
-const getSyncEvents = () => ({
-    CLI: 'cli',
-
-    BEFORE_FILE_READ: 'beforeFileRead',
-    AFTER_FILE_READ: 'afterFileRead',
-
-    AFTER_TESTS_READ: 'afterTestsRead',
-
+const getRunnerSyncEvents = () => ({
     SUITE_BEGIN: 'beginSuite',
     SUITE_END: 'endSuite',
 
@@ -34,7 +28,16 @@ const getSyncEvents = () => ({
     TEST_FAIL: 'failTest',
     TEST_PENDING: 'pendingTest',
 
-    RETRY: 'retry',
+    RETRY: 'retry'
+});
+
+const getSyncEvents = () => _.extend({}, getRunnerSyncEvents(), {
+    CLI: 'cli',
+
+    BEFORE_FILE_READ: 'beforeFileRead',
+    AFTER_FILE_READ: 'afterFileRead',
+
+    AFTER_TESTS_READ: 'afterTestsRead',
 
     INFO: 'info',
     WARNING: 'warning',
@@ -45,5 +48,6 @@ let events = _.extend(getSyncEvents(), getAsyncEvents());
 
 Object.defineProperty(events, 'getSync', {value: getSyncEvents, enumerable: false});
 Object.defineProperty(events, 'getAsync', {value: getAsyncEvents, enumerable: false});
+Object.defineProperty(events, 'getRunnerSync', {value: getRunnerSyncEvents, enumerable: false});
 
 module.exports = events;

--- a/lib/hermione.js
+++ b/lib/hermione.js
@@ -27,9 +27,9 @@ module.exports = class Hermione extends BaseHermione {
     async run(testPaths, {browsers, sets, grep, updateRefs, reporters, inspectMode} = {}) {
         validateUnknownBrowsers(browsers, _.keys(this._config.browsers));
 
-        this._runner = Runner.create(this._config)
+        this._runner = Runner.create(this._config, this._interceptors)
             .on(RunnerEvents.TEST_FAIL, () => this._fail())
-            .on(RunnerEvents.ERROR, () => this._fail());
+            .on(RunnerEvents.ERROR, (err) => this.halt(err));
 
         _.forEach(reporters, (reporter) => applyReporter(this._runner, reporter));
 

--- a/lib/runner/index.js
+++ b/lib/runner/index.js
@@ -14,10 +14,11 @@ const Workers = require('./workers');
 const logger = require('../utils/logger');
 
 module.exports = class MainRunner extends Runner {
-    constructor(config) {
+    constructor(config, interceptors) {
         super();
 
         this._config = config;
+        this._interceptors = interceptors;
         this._stats = RunnerStats.create();
         this._browserPool = pool.create(config, this);
 
@@ -51,7 +52,8 @@ module.exports = class MainRunner extends Runner {
     async _runTestsInBrowser(testCollection, browserId, workers) {
         const runner = BrowserRunner.create(browserId, this._config, this._browserPool);
 
-        eventsUtils.passthroughEvent(runner, this, _.values(Events.getSync()));
+        eventsUtils.passthroughEvent(runner, this, this._getEventsToPassthrough());
+        this._interceptEvents(runner, this._getEventsToIntercept());
         this._stats.attachRunner(runner);
 
         this._activeBrowserRunners.add(runner);
@@ -59,6 +61,35 @@ module.exports = class MainRunner extends Runner {
         await runner.run(testCollection, workers);
 
         this._activeBrowserRunners.delete(runner);
+    }
+
+    _getEventsToPassthrough() {
+        return _(Events.getRunnerSync()).values().difference(this._getEventsToIntercept()).value();
+    }
+
+    _getEventsToIntercept() {
+        return _(this._interceptors).map('event').uniq().value();
+    }
+
+    _interceptEvents(runner, events) {
+        events.forEach((event) => {
+            runner.on(event, (data) => {
+                try {
+                    this.emit(...this._applyInterceptors({event, data}, this._interceptors));
+                } catch (e) {
+                    this.emit(Events.ERROR, e);
+                }
+            });
+        });
+    }
+
+    _applyInterceptors({event, data} = {}, interceptors) {
+        const interceptor = _.find(interceptors, ['event', event]);
+        if (!interceptor) {
+            return [event, data];
+        }
+
+        return this._applyInterceptors(interceptor.handler({event, data}) || {event, data}, _.without(interceptors, interceptor));
     }
 
     cancel() {


### PR DESCRIPTION
Предполагается следующее API (сразу привожу пример как это будет использоваться в наших целях):

```js
module.exports = (hermione) => {
    hermione.intercept(hermione.events.TEST_FAIL, ({event, data}) => {
        if (/* muted test */) {
            data.pending = true;
            data.skipReason = 'failed muted test';

            return {event: hermione.events.TEST_PENDING, data};
        }
    });
};
```