### PR TITLE
fix: test meta from worker totally redefines test meta from master

### DIFF
--- a/lib/runner/test-runner/regular-test-runner.js
+++ b/lib/runner/test-runner/regular-test-runner.js
@@ -1,5 +1,6 @@
 'use strict';
 
+const _ = require('lodash');
 const Runner = require('../runner');
 const logger = require('../../utils/logger');
 const Events = require('../../constants/runner-events');
@@ -60,7 +61,7 @@ module.exports = class RegularTestRunner extends Runner {
         hermioneCtx.assertViewResults = AssertViewResults.fromRawObject(hermioneCtx.assertViewResults || []);
         this._test.assertViewResults = hermioneCtx.assertViewResults.get();
 
-        this._test.meta = meta;
+        this._test.meta = _.extend(this._test.meta, meta);
         this._test.hermioneCtx = hermioneCtx;
 
         this._browser && this._browser.applyState(browserState);

--- a/test/lib/runner/test-runner/regular-test-runner.js
+++ b/test/lib/runner/test-runner/regular-test-runner.js
@@ -183,6 +183,20 @@ describe('runner/test-runner/regular-test-runner', () => {
                 }));
             });
 
+            it('should extend test meta from master process by test meta from worker', async () => {
+                const onPass = sinon.stub().named('onPass');
+                const runner = mkRunner_({test: makeTest({meta: {foo: 'bar'}})})
+                    .on(Events.TEST_PASS, onPass);
+
+                Workers.prototype.runTest.resolves(stubTestResult_({meta: {baz: 'qux'}}));
+
+                await run_({runner});
+
+                assert.calledOnceWith(onPass, sinon.match({
+                    meta: {foo: 'bar', baz: 'qux'}
+                }));
+            });
+
             it('should be emitted with assert view results', async () => {
                 const onPass = sinon.stub().named('onPass');
                 const runner = mkRunner_()


### PR DESCRIPTION
Проблема заключается в том , что если, например, на событие `AFTER_TESTS_READ` записать каждому тесту что-то в meta, то на события `TEST_PASS`, `TEST_FAIL` и т. д. этой информации в meta уже не будет.