### PR TITLE
fix: stop escaping of special symbols in grep

### DIFF
--- a/lib/test-reader/mocha-test-parser.js
+++ b/lib/test-reader/mocha-test-parser.js
@@ -116,7 +116,7 @@ module.exports = class MochaTestParser extends EventEmitter {
 
     applyGrep(grep) {
         if (grep) {
-            this._mocha.grep(grep);
+            this._mocha.grep(new RegExp(grep));
         }
 
         return this;

--- a/test/lib/test-reader/mocha-test-parser.js
+++ b/test/lib/test-reader/mocha-test-parser.js
@@ -328,9 +328,9 @@ describe('test-reader/mocha-test-parser', () => {
         it('should add grep to mocha', () => {
             const mochaTestParser = mkMochaTestParser_();
 
-            mochaTestParser.applyGrep('foo bar');
+            mochaTestParser.applyGrep('(foo|bar)');
 
-            assert.calledOnceWith(MochaStub.lastInstance.grep, 'foo bar');
+            assert.calledOnceWith(MochaStub.lastInstance.grep, new RegExp('(foo|bar)'));
         });
 
         it('should not add empty grep to mocha', () => {


### PR DESCRIPTION
**Problem.**

We expect `npx hermione --grep="(foo|bar)"` to run both `foo` и `bar` tests, but instead none of them is run because special symbols are escaped: `/\(foo\|bar\)/ `.

**Solution.**

Pass already prepared `RegExp` object so that escaping doesn't occur.