### PR TITLE
fix: suite.id() no longer depends on parsing order

### DIFF
--- a/lib/test-reader/mocha-test-parser.js
+++ b/lib/test-reader/mocha-test-parser.js
@@ -74,8 +74,8 @@ module.exports = class MochaTestParser extends EventEmitter {
         });
 
         this.on(ParserEvents.SUITE, (suite) => {
-            const suiteIndex = suiteCounter++;
-            suite.id = () => `${getShortMD5(filePath)}${suiteIndex}`;
+            suite._id = `${getShortMD5(filePath)}${suiteCounter++}`;
+            suite.id = () => suite._id;
         });
     }
 

--- a/test/lib/test-reader/mocha-test-parser.js
+++ b/test/lib/test-reader/mocha-test-parser.js
@@ -304,6 +304,35 @@ describe('test-reader/mocha-test-parser', () => {
                 assert.equal(suite1.id(), '123450');
                 assert.equal(suite2.id(), '123451');
             });
+
+            it('"id" getter results should not be dependent on suite parsing order', () => {
+                crypto.getShortMD5.withArgs('/some/file.js').returns('12345');
+                crypto.getShortMD5.withArgs('/other/file.js').returns('67890');
+
+                mkMochaTestParser_();
+
+                MochaStub.lastInstance.suite.emit('pre-require', {}, '/some/file.js');
+                MochaStub.lastInstance.updateSuiteTree((suite) => {
+                    return suite
+                        .addSuite(MochaStub.Suite.create());
+                });
+
+                let suite1 = MochaStub.lastInstance.suite.suites[0];
+
+                assert.equal(suite1.id(), '123450');
+
+                MochaStub.lastInstance.suite.emit('pre-require', {}, '/other/file.js');
+                MochaStub.lastInstance.updateSuiteTree((suite) => {
+                    return suite
+                        .addSuite(MochaStub.Suite.create());
+                });
+
+                suite1 = MochaStub.lastInstance.suite.suites[0];
+                const suite2 = MochaStub.lastInstance.suite.suites[1];
+
+                assert.equal(suite1.id(), '123450');
+                assert.equal(suite2.id(), '678901');
+            });
         });
     });
 


### PR DESCRIPTION
Fix for the issue https://nda.ya.ru/3UXMrt

If `--grep` option is used, `pre-require` is triggered for all files in the set. Yet `suite.id()` is computed only when it is called.
Thus, `suite.id()` will return `id` derived from the last file in the set.