### PR TITLE
docs(readme): link to correct wdio version

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 Hermione
 ========
-Hermione is a utility for integration testing of web pages using [WebdriverIO](http://webdriver.io/) and [Mocha](https://mochajs.org).
+Hermione is a utility for integration testing of web pages using [WebdriverIO v4](http://v4.webdriver.io/api.html) and [Mocha](https://mochajs.org).
 
 <!-- START doctoc generated TOC please keep comment here to allow auto update -->
 <!-- DON'T EDIT THIS SECTION, INSTEAD RE-RUN doctoc TO UPDATE -->


### PR DESCRIPTION
Сейчас все ссылки с hermione ведут на оригинальный портал webdriver.io, но там api новой версии (v5) , и использовать её для разработки невозможно. 

Хорошо хотя бы ссылки бы обновить на верные, если нельзя отказаться от форка.