### PR TITLE
fix: forbid duplicate state names in 'assertView' within one test

### DIFF
--- a/README.md
+++ b/README.md
@@ -969,7 +969,7 @@ it('some test', function() {
 ```
 
 Parameters:
- - state (required) `String` – state name
+ - state (required) `String` – state name; should be unique within one test
  - selector (required) `String|String[]` – DOM-node selector that you need to capture
  - opts (optional) `Object`:
    - ignoreElements (optional) `String|String[]` – elements, matching specified selectors will be ignored when comparing images

--- a/lib/browser/commands/assert-view/assert-view-results.js
+++ b/lib/browser/commands/assert-view/assert-view-results.js
@@ -28,6 +28,10 @@ module.exports = class AssertViewResults {
         return this._results.some((res) => res instanceof Error);
     }
 
+    hasState(stateName) {
+        return this._results.some((res) => res.stateName === stateName);
+    }
+
     toRawObject() {
         return this._results.map((res) => ({...res}));
     }

--- a/lib/browser/commands/assert-view/errors/assert-view-error.js
+++ b/lib/browser/commands/assert-view/errors/assert-view-error.js
@@ -1,10 +1,10 @@
 'use strict';
 
 module.exports = class AssertViewError extends Error {
-    constructor() {
+    constructor(message) {
         super();
 
         this.name = this.constructor.name;
-        this.message = 'image comparison failed';
+        this.message = message || 'image comparison failed';
     }
 };

--- a/lib/browser/commands/assert-view/index.js
+++ b/lib/browser/commands/assert-view/index.js
@@ -8,6 +8,7 @@ const {getTestContext} = require('../../../utils/mocha');
 const RuntimeConfig = require('../../../config/runtime-config');
 const AssertViewResults = require('./assert-view-results');
 const BaseStateError = require('./errors/base-state-error');
+const AssertViewError = require('./errors/assert-view-error');
 
 module.exports = (browser) => {
     const screenShooter = ScreenShooter.create(browser);
@@ -21,6 +22,10 @@ module.exports = (browser) => {
 
         const test = getTestContext(session.executionContext);
         test.hermioneCtx.assertViewResults = test.hermioneCtx.assertViewResults || AssertViewResults.create();
+
+        if (test.hermioneCtx.assertViewResults.hasState(state)) {
+            return Promise.reject(new AssertViewError(`duplicate name for "${state}" state`));
+        }
 
         const handleCaptureProcessorError = (e) => e instanceof BaseStateError
             ? test.hermioneCtx.assertViewResults.add(e)

--- a/test/lib/browser/commands/assert-view/assert-view-results.js
+++ b/test/lib/browser/commands/assert-view/assert-view-results.js
@@ -55,6 +55,28 @@ describe('AssertViewResults', () => {
         });
     });
 
+    describe('hasState', () => {
+        it('should return "true" if state exists', () => {
+            const assertViewResults = AssertViewResults.create();
+
+            assertViewResults.add({stateName: 'foo'});
+            assertViewResults.add({stateName: 'bar'});
+
+            assert.isTrue(assertViewResults.hasState('foo'));
+            assert.isTrue(assertViewResults.hasState('bar'));
+        });
+
+        it('should return "false" if state does not exist', () => {
+            const assertViewResults = AssertViewResults.create();
+
+            assertViewResults.add({stateName: 'foo'});
+            assertViewResults.add({stateName: 'bar'});
+
+            assert.isFalse(assertViewResults.hasState('baz'));
+            assert.isFalse(assertViewResults.hasState('qux'));
+        });
+    });
+
     describe('toRawObject', () => {
         it('should transform result to raw object', () => {
             const assertViewResults = AssertViewResults.create();

--- a/test/lib/browser/commands/assert-view/errors/assert-view-error.js
+++ b/test/lib/browser/commands/assert-view/errors/assert-view-error.js
@@ -6,4 +6,12 @@ describe('AssertViewError', () => {
     it('should be an instance of Error', () => {
         assert.instanceOf(new AssertViewError(), Error);
     });
+
+    it('should have default error message', () => {
+        assert.equal(new AssertViewError().message, 'image comparison failed');
+    });
+
+    it('should allow to overwrite default error message', () => {
+        assert.equal(new AssertViewError('foo bar').message, 'foo bar');
+    });
 });

--- a/test/lib/browser/commands/assert-view/index.js
+++ b/test/lib/browser/commands/assert-view/index.js
@@ -4,6 +4,7 @@ const _ = require('lodash');
 const fs = require('fs-extra');
 const webdriverio = require('@gemini-testing/webdriverio');
 const {Image, temp, ScreenShooter} = require('gemini-core');
+const AssertViewError = require('lib/browser/commands/assert-view/errors/assert-view-error');
 const ImageDiffError = require('lib/browser/commands/assert-view/errors/image-diff-error');
 const NoRefImageError = require('lib/browser/commands/assert-view/errors/no-ref-image-error');
 const RuntimeConfig = require('lib/config/runtime-config');
@@ -64,6 +65,19 @@ describe('assertView command', () => {
     });
 
     afterEach(() => sandbox.restore());
+
+    it('should fail on duplicate name of the state', async () => {
+        const browser = stubBrowser_();
+
+        await browser.publicAPI.assertView('plain');
+
+        try {
+            await browser.publicAPI.assertView('plain');
+        } catch (e) {
+            assert.instanceOf(e, AssertViewError);
+            assert.equal(e.message, 'duplicate name for "plain" state');
+        }
+    });
 
     describe('prepare screenshot', () => {
         it('should prepare screenshot for one selector', async () => {
@@ -168,8 +182,8 @@ describe('assertView command', () => {
 
         const browser = stubBrowser_();
 
-        await browser.publicAPI.assertView();
-        await browser.publicAPI.assertView();
+        await browser.publicAPI.assertView('foo');
+        await browser.publicAPI.assertView('bar');
 
         const [firstError, secondError] = browser.publicAPI.executionContext.hermioneCtx.assertViewResults.get();
         assert.instanceOf(firstError, NoRefImageError);
@@ -289,8 +303,8 @@ describe('assertView command', () => {
                 it('should remember several "ImageDiffError" errors', async () => {
                     const browser = stubBrowser_();
 
-                    await browser.publicAPI.assertView();
-                    await browser.publicAPI.assertView();
+                    await browser.publicAPI.assertView('foo');
+                    await browser.publicAPI.assertView('bar');
 
                     const [firstError, secondError] = browser.publicAPI.executionContext.hermioneCtx.assertViewResults.get();
                     assert.instanceOf(firstError, ImageDiffError);


### PR DESCRIPTION
BREAKING CHANGE: test with duplicate state names in 'assertView' calls will fail with 'AssertViewError'