### PR TITLE
feat: do not pass tests' statistic on 'END' event

### DIFF
--- a/lib/runner/index.js
+++ b/lib/runner/index.js
@@ -45,7 +45,7 @@ module.exports = class MainRunner extends Runner {
             !this._cancelled && await this._runTests(testCollection);
         } finally {
             this._workers.end();
-            this.emit(Events.END, stats.getResult());
+            this.emit(Events.END);
             await this.emitAndWait(Events.RUNNER_END, stats.getResult()).catch(logger.warn);
         }
     }

--- a/test/lib/runner/index.js
+++ b/test/lib/runner/index.js
@@ -431,19 +431,6 @@ describe('Runner', () => {
                 assert.calledOnce(onEnd);
             });
 
-            it('should pass test statistic to an END handler', async () => {
-                const stats = sinon.createStubInstance(RunnerStats);
-                stats.getResult.returns({foo: 'bar'});
-
-                const onEnd = sinon.stub().named('onEnd');
-                const runner = new Runner(makeConfigStub())
-                    .on(RunnerEvents.END, onEnd);
-
-                await run_({runner, stats});
-
-                assert.calledOnceWith(onEnd, {foo: 'bar'});
-            });
-
             it('should be emitted before RUNNER_END event', async () => {
                 const onEnd = sinon.spy().named('onEnd');
                 const onRunnerEnd = sinon.spy().named('onRunnerEnd');


### PR DESCRIPTION
BREAKING CHANGE: 'END' event handler will not recieve tests' statistic as the first argument