### PR TITLE
fix: slow build image diff

### DIFF
--- a/lib/browser/commands/assert-view/capture-processors/assert-refs.js
+++ b/lib/browser/commands/assert-view/capture-processors/assert-refs.js
@@ -1,21 +1,24 @@
 'use strict';
 
-const Promise = require('bluebird');
 const ImageDiffError = require('../errors/image-diff-error');
 const NoRefImageError = require('../errors/no-ref-image-error');
+const {saveDiff} = require('./save-diff');
 
 exports.handleNoRefImage = (currImg, refImg, state) => {
     return Promise.reject(NoRefImageError.create(state, currImg, refImg));
 };
 
-exports.handleImageDiff = (currImg, refImg, state, opts) => {
+exports.handleImageDiff = async (currImg, refImg, diffImg, state, opts) => {
     const {diffAreas, config} = opts;
     const {tolerance, antialiasingTolerance, buildDiffOpts, system: {diffColor}} = config;
 
     const diffOpts = {
-        current: currImg.path, reference: refImg.path,
         diffColor, tolerance, antialiasingTolerance, ...buildDiffOpts
     };
 
-    return Promise.reject(ImageDiffError.create(state, currImg, refImg, diffOpts, diffAreas));
+    diffImg.path = await saveDiff(currImg.path, refImg.path, diffImg.path, diffOpts);
+
+    const error = ImageDiffError.create(state, currImg, refImg, diffImg, diffAreas);
+
+    return Promise.reject(error);
 };

--- a/lib/browser/commands/assert-view/capture-processors/save-diff.js
+++ b/lib/browser/commands/assert-view/capture-processors/save-diff.js
@@ -1,0 +1,42 @@
+'use strict';
+
+const crypto = require('crypto');
+const fs = require('fs-extra');
+
+const Promise = require('bluebird');
+const {Image} = require('gemini-core');
+
+// Need to cache the result of 'Image.buildDiff' because it is slow.
+const globalCache = new Map();
+
+exports.saveDiff = async (curPath, refPath, diffPath, diffOpts, cache = globalCache) => {
+    const [curBuffer, refBuffer] = await Promise.all([
+        fs.readFile(curPath),
+        fs.readFile(refPath)
+    ]);
+
+    const hash = createHash(curBuffer) + createHash(refBuffer);
+
+    if (cache.has(hash)) {
+        return cache.get(hash);
+    }
+
+    const diffBuffer = await Image.buildDiff({
+        ...diffOpts,
+        current: curBuffer,
+        reference: refBuffer
+    });
+
+    await fs.writeFile(diffPath, diffBuffer);
+
+    cache.set(hash, diffPath);
+
+    return diffPath;
+};
+
+function createHash(buffer) {
+    return crypto
+        .createHash('sha1')
+        .update(buffer)
+        .digest('base64');
+}

--- a/lib/browser/commands/assert-view/errors/image-diff-error.js
+++ b/lib/browser/commands/assert-view/errors/image-diff-error.js
@@ -1,6 +1,5 @@
 'use strict';
 
-const {Image} = require('gemini-core');
 const BaseStateError = require('./base-state-error');
 
 module.exports = class ImageDiffError extends BaseStateError {
@@ -10,19 +9,15 @@ module.exports = class ImageDiffError extends BaseStateError {
 
     static fromObject(data) {
         const {diffBounds, diffClusters} = data;
-        return new ImageDiffError(data.stateName, data.currImg, data.refImg, data.diffOpts, {diffBounds, diffClusters});
+        return new ImageDiffError(data.stateName, data.currImg, data.refImg, data.diffImg, {diffBounds, diffClusters});
     }
 
-    constructor(stateName, currImg, refImg, diffOpts, {diffBounds, diffClusters} = {}) {
+    constructor(stateName, currImg, refImg, diffImg, {diffBounds, diffClusters} = {}) {
         super(stateName, currImg, refImg);
 
+        this.diffImg = diffImg;
         this.message = `images are different for "${stateName}" state`;
-        this.diffOpts = diffOpts;
         this.diffBounds = diffBounds;
         this.diffClusters = diffClusters;
-    }
-
-    saveDiffTo(diffPath) {
-        return Image.buildDiff({diff: diffPath, ...this.diffOpts});
     }
 };

--- a/lib/browser/commands/assert-view/index.js
+++ b/lib/browser/commands/assert-view/index.js
@@ -54,7 +54,7 @@ module.exports = (browser) => {
 
         const refImg = {path: config.getScreenshotPath(test, state), size: null};
 
-        if (!fs.existsSync(refImg.path)) {
+        if (!(await fs.exists(refImg.path))) {
             return handleNoRefImage(currImg, refImg, state).catch((e) => handleCaptureProcessorError(e));
         }
 
@@ -73,7 +73,8 @@ module.exports = (browser) => {
             const diffAreas = {diffBounds, diffClusters};
             const opts = {diffAreas, config};
 
-            return handleImageDiff(currImg, refImg, state, opts).catch((e) => handleCaptureProcessorError(e));
+            const diffImg = {path: temp.path(Object.assign(tempOpts, {suffix: '.png'}))};
+            return handleImageDiff(currImg, refImg, diffImg, state, opts).catch((e) => handleCaptureProcessorError(e));
         }
 
         test.hermioneCtx.assertViewResults.add({stateName: state, refImg: refImg});

--- a/test/lib/browser/commands/assert-view/capture-processors/saveDiff.js
+++ b/test/lib/browser/commands/assert-view/capture-processors/saveDiff.js
@@ -1,0 +1,101 @@
+'use strict';
+
+const {saveDiff} = require('lib/browser/commands/assert-view/capture-processors/save-diff');
+const fs = require('fs-extra');
+const {Image} = require('gemini-core');
+
+const curPath = '/curPath.png';
+const refPath = '/refPath.png';
+const diffPath = '/diffPath.png';
+const diffOpts = {
+    foo: 'bar'
+};
+const diffBuffer = Buffer.from('foobar');
+
+describe('browser/commands/assert-view/capture-processors/save-diff', () => {
+    const sandbox = sinon.createSandbox();
+    let cache;
+
+    beforeEach(() => {
+        cache = new Map();
+
+        sandbox.stub(fs, 'readFile');
+        sandbox.stub(fs, 'writeFile');
+        sandbox.stub(Image, 'buildDiff').resolves(diffBuffer);
+
+        fs.readFile.withArgs(curPath).resolves(Buffer.from('currentContent'));
+        fs.readFile.withArgs(refPath).resolves(Buffer.from('referenceContent'));
+    });
+
+    afterEach(() => sandbox.restore());
+
+    it('should get result from cache for second call if data not changed', async () => {
+        await saveDiff(curPath, refPath, '/firstDiffPath.png', diffOpts, cache);
+        const result = await saveDiff(curPath, refPath, diffPath, diffOpts, cache);
+
+        assert.strictEqual(result, '/firstDiffPath.png');
+        assert.calledOnceWith(
+            Image.buildDiff,
+            sinon.match({
+                foo: 'bar',
+                current: Buffer.from('currentContent'),
+                reference: Buffer.from('referenceContent')
+            })
+        );
+        assert.calledOnceWith(
+            fs.writeFile,
+            sinon.match('/firstDiffPath.png'),
+            sinon.match(diffBuffer)
+        );
+    });
+
+    it('should build diff for second call if current image changed ', async () => {
+        await saveDiff(curPath, refPath, 'firstDiffPath', diffOpts, cache);
+
+        fs.readFile.withArgs(curPath).resolves(Buffer.from('changedCurrentContent'));
+
+        const result = await saveDiff(curPath, refPath, diffPath, diffOpts, cache);
+
+        assert.strictEqual(result, diffPath);
+        assert.calledTwice(Image.buildDiff);
+        assert.calledWith(
+            Image.buildDiff,
+            sinon.match({
+                foo: 'bar',
+                current: Buffer.from('changedCurrentContent'),
+                reference: Buffer.from('referenceContent')
+            })
+        );
+        assert.calledTwice(fs.writeFile);
+        assert.calledWith(
+            fs.writeFile,
+            sinon.match(diffPath),
+            sinon.match(diffBuffer)
+        );
+    });
+
+    it('should build diff for second call if reference image changed ', async () => {
+        await saveDiff(curPath, refPath, 'firstDiffPath', diffOpts, cache);
+
+        fs.readFile.withArgs(refPath).resolves(Buffer.from('changedReferenceContent'));
+
+        const result = await saveDiff(curPath, refPath, diffPath, diffOpts, cache);
+
+        assert.strictEqual(result, diffPath);
+        assert.calledTwice(Image.buildDiff);
+        assert.calledWith(
+            Image.buildDiff,
+            sinon.match({
+                foo: 'bar',
+                current: Buffer.from('currentContent'),
+                reference: Buffer.from('changedReferenceContent')
+            })
+        );
+        assert.calledTwice(fs.writeFile);
+        assert.calledWith(
+            fs.writeFile,
+            sinon.match(diffPath),
+            sinon.match(diffBuffer)
+        );
+    });
+});

--- a/test/lib/browser/commands/assert-view/errors/image-diff-error.js
+++ b/test/lib/browser/commands/assert-view/errors/image-diff-error.js
@@ -1,7 +1,6 @@
 'use strict';
 
 const _ = require('lodash');
-const {Image} = require('gemini-core');
 const BaseStateError = require('lib/browser/commands/assert-view/errors/base-state-error');
 const ImageDiffError = require('lib/browser/commands/assert-view/errors/image-diff-error');
 
@@ -9,22 +8,13 @@ const mkImageDiffError = (opts = {}) => {
     const {stateName, currImg, refImg, diffOpts} = _.defaults(opts, {
         stateName: 'default-name',
         currImg: {path: '/default-curr/path'},
-        refImg: {path: '/default-ref/path'},
-        diffOpts: {foo: 'bar'}
+        refImg: {path: '/default-ref/path'}
     });
 
     return new ImageDiffError(stateName, currImg, refImg, diffOpts);
 };
 
 describe('ImageDiffError', () => {
-    const sandbox = sinon.sandbox.create();
-
-    beforeEach(() => {
-        sandbox.stub(Image, 'buildDiff').resolves();
-    });
-
-    afterEach(() => sandbox.restore());
-
     it('should be an instance of "BaseStateError"', () => {
         assert.instanceOf(mkImageDiffError(), BaseStateError);
     });
@@ -57,34 +47,18 @@ describe('ImageDiffError', () => {
         assert.deepEqual(error.refImg, {path: '/ref/path'});
     });
 
-    it('should contain options for image diff building', () => {
-        const error = mkImageDiffError({diffOpts: {some: 'opts'}});
-
-        assert.deepEqual(error.diffOpts, {some: 'opts'});
-    });
-
     it('should create an instance of error from object', () => {
         const error = ImageDiffError.fromObject({
             stateName: 'name',
             currImg: {path: 'curr/path'},
-            refImg: {path: 'ref/path'},
-            diffOpts: {foo: 'bar'}
+            refImg: {path: 'ref/path'}
         });
 
         assert.instanceOf(error, ImageDiffError);
         assert.deepInclude(Object.assign({}, error), {
             stateName: 'name',
             currImg: {path: 'curr/path'},
-            refImg: {path: 'ref/path'},
-            diffOpts: {foo: 'bar'}
+            refImg: {path: 'ref/path'}
         });
-    });
-
-    it('should provide the ability to save diff image', () => {
-        const error = mkImageDiffError({diffOpts: {some: 'opts'}});
-
-        Image.buildDiff.withArgs({some: 'opts', diff: 'diff/path'}).resolves({foo: 'bar'});
-
-        return assert.becomes(error.saveDiffTo('diff/path'), {foo: 'bar'});
     });
 });


### PR DESCRIPTION
BREAKING CHANGE: remove method 'saveDiffTo' from ImageDiffError

Related PR:
https://github.com/gemini-testing/html-reporter/pull/220