### PR TITLE
Fix: do not sort empty TestCollection

### DIFF
--- a/lib/test-collection.js
+++ b/lib/test-collection.js
@@ -53,11 +53,13 @@ module.exports = class TestCollection {
         }
 
         if (browserId) {
-            let pairs = _.zip(this._specs[browserId], this._originalSpecs[browserId]);
+            if (this._specs[browserId].length) {
+                let pairs = _.zip(this._specs[browserId], this._originalSpecs[browserId]);
 
-            pairs.sort((p1, p2) => cb(p1[0], p2[0]));
+                pairs.sort((p1, p2) => cb(p1[0], p2[0]));
 
-            [this._specs[browserId], this._originalSpecs[browserId]] = _.unzip(pairs);
+                [this._specs[browserId], this._originalSpecs[browserId]] = _.unzip(pairs);
+            }
         } else {
             this.getBrowsers().forEach((browserId) => this.sortTests(browserId, cb));
         }

--- a/test/lib/test-collection.js
+++ b/test/lib/test-collection.js
@@ -62,6 +62,18 @@ describe('test-collection', () => {
     });
 
     describe('sortTests', () => {
+        it('should do nothing if there are no tests for the specified browser', () => {
+            const collection = TestCollection.create({
+                'bro1': [],
+                'bro2': []
+            });
+
+            collection.sortTests('bro1', (a, b) => a.title < b.title);
+
+            assert.deepEqual(collection.mapTests('bro1', (t) => t), []);
+            assert.deepEqual(collection.mapTests('bro2', (t) => t), []);
+        });
+
         it('should sort all tests for the specified browser', () => {
             const test1 = {title: 'test1'};
             const test2 = {title: 'test2'};


### PR DESCRIPTION
`_.zip([], [])` returns empty array which leads to undefined values on subsequent unzipping.