### PR TITLE
fix: logic of ignore caret option on ImageDiffError

### DIFF
--- a/lib/browser/commands/assert-view/capture-processors/assert-refs.js
+++ b/lib/browser/commands/assert-view/capture-processors/assert-refs.js
@@ -9,8 +9,9 @@ exports.handleNoRefImage = (currImg, refImg, state) => {
 };
 
 exports.handleImageDiff = (currImg, refImg, state, opts) => {
-    const {diffAreas, config} = opts;
+    const {canHaveCaret, diffAreas, config} = opts;
     const {tolerance, antialiasingTolerance, buildDiffOpts, system: {diffColor}} = config;
+    buildDiffOpts.ignoreCaret = buildDiffOpts.ignoreCaret && canHaveCaret;
 
     const diffOpts = {
         current: currImg.path, reference: refImg.path,

--- a/lib/browser/commands/assert-view/index.js
+++ b/lib/browser/commands/assert-view/index.js
@@ -72,7 +72,7 @@ module.exports = (browser) => {
 
         if (!equal) {
             const diffAreas = {diffBounds, diffClusters};
-            const opts = {diffAreas, config, emitter};
+            const opts = {canHaveCaret, diffAreas, config, emitter};
 
             return handleImageDiff(currImg, refImg, state, opts).catch((e) => handleCaptureProcessorError(e));
         }

--- a/test/lib/browser/commands/assert-view/capture-processors/assert-refs.js
+++ b/test/lib/browser/commands/assert-view/capture-processors/assert-refs.js
@@ -30,7 +30,8 @@ describe('browser/commands/assert-view/capture-processors/assert-refs', () => {
                 state: 'default-state',
                 diffOpts: {
                     diffBounds: 'default-bounds',
-                    config: mkConfig_(opts.config)
+                    config: mkConfig_(opts.config),
+                    canHaveCaret: opts.canHaveCaret
                 }
             });
 
@@ -53,7 +54,7 @@ describe('browser/commands/assert-view/capture-processors/assert-refs', () => {
                     });
             });
 
-            it('with overriden diff option from "buildDiffOpts"', async () => {
+            it('overriden diff option from "buildDiffOpts"', async () => {
                 const config = {
                     buildDiffOpts: {tolerance: 100500},
                     tolerance: 500100
@@ -65,6 +66,53 @@ describe('browser/commands/assert-view/capture-processors/assert-refs', () => {
                             ImageDiffError.create,
                             sinon.match.any, sinon.match.any, sinon.match.any,
                             sinon.match({tolerance: 100500})
+                        );
+                    });
+            });
+
+            describe('not ignore caret if', () => {
+                it('none of the editable elements are in focus', async () => {
+                    const config = {
+                        buildDiffOpts: {ignoreCaret: true}
+                    };
+
+                    await handleImageDiff_({config, canHaveCaret: false})
+                        .catch(() => {
+                            assert.calledOnceWith(
+                                ImageDiffError.create,
+                                sinon.match.any, sinon.match.any, sinon.match.any,
+                                sinon.match({ignoreCaret: false})
+                            );
+                        });
+                });
+
+                it('in config is explicitly set not to ignore it', async () => {
+                    const config = {
+                        buildDiffOpts: {ignoreCaret: false}
+                    };
+
+                    await handleImageDiff_({config, canHaveCaret: true})
+                        .catch(() => {
+                            assert.calledOnceWith(
+                                ImageDiffError.create,
+                                sinon.match.any, sinon.match.any, sinon.match.any,
+                                sinon.match({ignoreCaret: false})
+                            );
+                        });
+                });
+            });
+
+            it('ignore caret if one of the editable elements are in focus', async () => {
+                const config = {
+                    buildDiffOpts: {ignoreCaret: true}
+                };
+
+                await handleImageDiff_({config, canHaveCaret: true})
+                    .catch(() => {
+                        assert.calledOnceWith(
+                            ImageDiffError.create,
+                            sinon.match.any, sinon.match.any, sinon.match.any,
+                            sinon.match({ignoreCaret: true})
                         );
                     });
             });

--- a/test/lib/browser/commands/assert-view/index.js
+++ b/test/lib/browser/commands/assert-view/index.js
@@ -425,13 +425,14 @@ describe('assertView command', () => {
 
                 it('should pass browser emitter to "handleImageDiff" handler', async () => {
                     const browser = stubBrowser_();
+                    browser.prepareScreenshot.resolves({canHaveCaret: true});
 
                     await browser.publicAPI.assertView();
 
                     assert.calledOnceWith(
                         updateRefs.handleImageDiff,
                         sinon.match.any, sinon.match.any, sinon.match.any,
-                        {config: sinon.match.any, diffAreas: sinon.match.any, emitter: browser.emitter}
+                        {canHaveCaret: true, config: sinon.match.any, diffAreas: sinon.match.any, emitter: browser.emitter}
                     );
                 });
             });

--- a/test/lib/browser/utils.js
+++ b/test/lib/browser/utils.js
@@ -21,7 +21,10 @@ function createBrowserConfig_(opts = {}) {
         screenshotDelay: 0,
         windowSize: null,
         getScreenshotPath: () => '/some/path',
-        system: opts.system || {}
+        system: opts.system || {},
+        buildDiffOpts: {
+            ignoreCaret: true
+        }
     });
 
     return {


### PR DESCRIPTION
Do not ignore caret if none of the editable elements are in focus