### PR TITLE
fix: make test.id looks like a property

### DIFF
--- a/lib/test-reader/mocha-test-parser.js
+++ b/lib/test-reader/mocha-test-parser.js
@@ -85,14 +85,18 @@ module.exports = class MochaTestParser extends EventEmitter {
         });
 
         this.on(ParserEvents.SUITE, (suite) => {
-            suite._id = `${getShortMD5(filePath)}${suiteCounter++}`;
-            suite.id = () => suite._id;
+            const id = `${getShortMD5(filePath)}${suiteCounter++}`;
+            suite.id = () => id;
+            suite.id.toString = () => id;
         });
     }
 
     _extendTestApi() {
         this.on(ParserEvents.TEST, (test) => {
-            test.id = () => getShortMD5(test.fullTitle());
+            const id = getShortMD5(test.fullTitle());
+            test.id = () => id;
+            test.id.toString = () => id;
+
             test.browserId = this._browserId;
         });
     }

--- a/test/lib/test-reader/mocha-test-parser.js
+++ b/test/lib/test-reader/mocha-test-parser.js
@@ -331,6 +331,9 @@ describe('test-reader/mocha-test-parser', () => {
 
                 assert.equal(suite1.id(), '123450');
                 assert.equal(suite2.id(), '123451');
+
+                assert.equal(suite1.id, '123450');
+                assert.equal(suite2.id, '123451');
             });
 
             it('"id" getter results should not be dependent on suite parsing order', () => {
@@ -441,6 +444,7 @@ describe('test-reader/mocha-test-parser', () => {
             const test = MochaStub.lastInstance.suite.tests[0];
 
             assert.equal(test.id(), '12345');
+            assert.equal(test.id, '12345');
         });
 
         it('shold set browserId property to test', () => {


### PR DESCRIPTION
Пока оставил для обратной совместимости `id` как функцию. В следующем мажоре выпилим