### PR TITLE
fix: always release browser

### DIFF
--- a/lib/runner/test-runner/regular-test-runner.js
+++ b/lib/runner/test-runner/regular-test-runner.js
@@ -43,7 +43,7 @@ module.exports = class RegularTestRunner extends Runner {
 
         this._emit(Events.TEST_END);
 
-        await freeBrowserPromise;
+        await (freeBrowserPromise || this._freeBrowser());
     }
 
     _emit(event) {
@@ -84,15 +84,18 @@ module.exports = class RegularTestRunner extends Runner {
         }
     }
 
-    async _freeBrowser(browserState) {
+    async _freeBrowser(browserState = {}) {
         if (!this._browser) {
             return;
         }
 
-        this._browser.applyState(browserState);
+        const browser = this._browser;
+        this._browser = null;
+
+        browser.applyState(browserState);
 
         try {
-            await this._browserAgent.freeBrowser(this._browser);
+            await this._browserAgent.freeBrowser(browser);
         } catch (error) {
             logger.warn(`WARNING: can not release browser: ${error}`);
         }

--- a/test/lib/runner/test-runner/regular-test-runner.js
+++ b/test/lib/runner/test-runner/regular-test-runner.js
@@ -516,6 +516,28 @@ describe('runner/test-runner/regular-test-runner', () => {
 
                 assert.notCalled(onTestFail);
             });
+
+            it('should release browser even if no event from worker', async () => {
+                const browser = stubBrowser_();
+                BrowserAgent.prototype.getBrowser.resolves(browser);
+
+                await runTest_({
+                    onRun: () => {}
+                });
+
+                assert.calledOnceWith(BrowserAgent.prototype.freeBrowser, browser);
+            });
+
+            it('should release browser only once on late event', async () => {
+                let delayedEmit;
+
+                await runTest_({onRun: ({workers, test}) => {
+                    delayedEmit = () => workers.emit(`worker.${test.id}.${test.browserId}.freeBrowser`);
+                }});
+                delayedEmit();
+
+                assert.calledOnce(BrowserAgent.prototype.freeBrowser);
+            });
         });
     });
 });


### PR DESCRIPTION
Fallback to force free browser if there was no freeBrowser event from worker