### PR TITLE
chore: up webdriverio version

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -176,9 +176,9 @@
       "integrity": "sha512-hjTona7ySenkm+qKGAJ2uEAa1Y/VFZ14ieMWUwlb7MGoBPL3VVoTwEL7bCQiOvbDc2ld5LnDmzzJYcWAw9psbg=="
     },
     "@gemini-testing/webdriverio": {
-      "version": "4.15.4",
-      "resolved": "https://registry.npmjs.org/@gemini-testing/webdriverio/-/webdriverio-4.15.4.tgz",
-      "integrity": "sha512-kHAbMhjv1UOLD6/Wxwi6aO8uiuzula129cvdKwisx7+M9n8UkjxSrvIIjGCqdM7pO5VQ/ocw054efepqFrT++Q==",
+      "version": "4.16.1",
+      "resolved": "https://registry.npmjs.org/@gemini-testing/webdriverio/-/webdriverio-4.16.1.tgz",
+      "integrity": "sha512-tZBl8RBMwPnw6OKtg+TaCDBUtpxkjlfkMAaDJ0xL/jGlQA6pIWwn5/L21wKuekybXqOpVeuVEqgFfW7hjBMN8g==",
       "requires": {
         "archiver": "~2.1.0",
         "babel-runtime": "^6.26.0",
@@ -972,9 +972,9 @@
       }
     },
     "buffer": {
-      "version": "5.2.1",
-      "resolved": "https://registry.npmjs.org/buffer/-/buffer-5.2.1.tgz",
-      "integrity": "sha512-c+Ko0loDaFfuPWiL02ls9Xd3GO3cPVmUobQ6t3rXNUk304u6hGq+8N/kFi+QEIKhzK3uwolVhLzszmfLmMLnqg==",
+      "version": "5.4.0",
+      "resolved": "https://registry.npmjs.org/buffer/-/buffer-5.4.0.tgz",
+      "integrity": "sha512-Xpgy0IwHK2N01ncykXTy6FpCWuM+CJSHoPVBLyNqyrWxsedpLvwsYUhf0ME3WRFNUhos0dMamz9cOS/xRDtU5g==",
       "requires": {
         "base64-js": "^1.0.2",
         "ieee754": "^1.1.4"

--- a/package.json
+++ b/package.json
@@ -32,7 +32,7 @@
   "license": "MIT",
   "dependencies": {
     "@gemini-testing/commander": "2.15.2",
-    "@gemini-testing/webdriverio": "4.15.4",
+    "@gemini-testing/webdriverio": "4.16.1",
     "bluebird": "^3.5.1",
     "bluebird-q": "^2.1.1",
     "chalk": "^1.1.1",


### PR DESCRIPTION
In version `4.16.1` of `@gemini-testing/webdriverio` we have extended `ESOCKETTIMEDOUT` messages: with browser commands and their arguments added to the messages.