### PR TITLE
Feat: added different styles of ignore areas

### DIFF
--- a/README.md
+++ b/README.md
@@ -610,6 +610,7 @@ Read more about this option in [looks-same](https://github.com/gemini-testing/lo
 Extra options for comparing images. See [looks-same](https://github.com/gemini-testing/looks-same#comparing-images) documentation for the list of available options. Default values are:
 ```javascript
 compareOpts: {
+    ignoreElementsStyle: 'solid',
     stopOnFirstFail: false
 }
 ```

--- a/README.md
+++ b/README.md
@@ -615,6 +615,11 @@ compareOpts: {
 }
 ```
 
+##### ignoreElementsStyle
+How ignore elements will be represented on the screenshot.
+- `solid` – black rectangles
+- `none` – no visual hint on screenshots, composited on diff
+
 #### buildDiffOpts
 Extra options for building diff image. See [looks-same](https://github.com/gemini-testing/looks-same#building-diff-image) documentation for the list of available options. Default values are:
 ```javascript
@@ -1018,6 +1023,7 @@ Parameters:
  - selector (required) `String|String[]` – DOM-node selector that you need to capture
  - opts (optional) `Object`:
    - ignoreElements (optional) `String|String[]` – elements, matching specified selectors will be ignored when comparing images
+   - ignoreElementsStyle (optional) `'solid'|'none'` – representation of ignoreElements on the screenshot. `solid` – black rectangles, `none` – no visual hint on screenshots, composited on diff
    - tolerance (optional) `Number` – overrides config [browsers](#browsers).[tolerance](#tolerance) value
    - allowViewportOverflow (optional) `Boolean` – by default Hermione throws an error if element is outside the viewport's bounds, this option disables such check and makes command to screenshot the visible part of the element
 

--- a/lib/browser/commands/assert-view/capture-processors/assert-refs.js
+++ b/lib/browser/commands/assert-view/capture-processors/assert-refs.js
@@ -9,11 +9,12 @@ exports.handleNoRefImage = (currImg, refImg, state) => {
 };
 
 exports.handleImageDiff = (currImg, refImg, state, opts) => {
-    const {canHaveCaret, diffAreas, config} = opts;
+    const {canHaveCaret, diffAreas, config, ignoreAreas} = opts;
     const {tolerance, antialiasingTolerance, buildDiffOpts, system: {diffColor}} = config;
     buildDiffOpts.ignoreCaret = buildDiffOpts.ignoreCaret && canHaveCaret;
 
     const diffOpts = {
+        ignoreAreas,
         current: currImg.path, reference: refImg.path,
         diffColor, tolerance, antialiasingTolerance, ...buildDiffOpts
     };

--- a/lib/browser/commands/assert-view/capture-processors/assert-refs.js
+++ b/lib/browser/commands/assert-view/capture-processors/assert-refs.js
@@ -14,9 +14,8 @@ exports.handleImageDiff = (currImg, refImg, state, opts) => {
     buildDiffOpts.ignoreCaret = buildDiffOpts.ignoreCaret && canHaveCaret;
 
     const diffOpts = {
-        ignoreAreas,
         current: currImg.path, reference: refImg.path,
-        diffColor, tolerance, antialiasingTolerance, ...buildDiffOpts
+        diffColor, tolerance, antialiasingTolerance, ignoreAreas, ...buildDiffOpts
     };
 
     return Promise.reject(ImageDiffError.create(state, currImg, refImg, diffOpts, diffAreas));

--- a/lib/browser/commands/assert-view/index.js
+++ b/lib/browser/commands/assert-view/index.js
@@ -62,7 +62,6 @@ module.exports = (browser) => {
         }
 
         const {canHaveCaret, pixelRatio} = page;
-
         const imageCompareOpts = {
             tolerance: opts.tolerance,
             antialiasingTolerance,

--- a/lib/browser/commands/assert-view/index.js
+++ b/lib/browser/commands/assert-view/index.js
@@ -14,13 +14,13 @@ module.exports = (browser) => {
     const screenShooter = ScreenShooter.create(browser);
     const {publicAPI: session, config} = browser;
     const {tolerance, antialiasingTolerance, compareOpts, screenshotDelay} = config;
-    const {ignoreStyle} = compareOpts;
+    const {ignoreElementsStyle} = compareOpts;
     const {handleNoRefImage, handleImageDiff} = getCaptureProcessors();
 
     session.addCommand('assertView', async (state, selectors, opts = {}) => {
         opts = _.defaults(opts, {
-            ignoreStyle,
             ignoreElements: [],
+            ignoreElementsStyle,
             tolerance,
             allowViewportOverflow: false,
             screenshotDelay
@@ -46,7 +46,7 @@ module.exports = (browser) => {
 
         const screenShooterOpts = {
             allowViewportOverflow: opts.allowViewportOverflow,
-            ignoreStyle: opts.ignoreStyle,
+            ignoreElementsStyle: opts.ignoreElementsStyle,
             screenshotDelay: opts.screenshotDelay
         };
 

--- a/lib/browser/commands/assert-view/index.js
+++ b/lib/browser/commands/assert-view/index.js
@@ -13,12 +13,13 @@ const AssertViewError = require('./errors/assert-view-error');
 module.exports = (browser) => {
     const screenShooter = ScreenShooter.create(browser);
     const {publicAPI: session, config} = browser;
-    const {tolerance, antialiasingTolerance, compareOpts, screenshotDelay} = config;
+    const {tolerance, antialiasingTolerance, compareOpts, screenshotDelay, system: {ignoreStyle}} = config;
 
     const {handleNoRefImage, handleImageDiff} = getCaptureProcessors();
 
     session.addCommand('assertView', async (state, selectors, opts = {}) => {
         opts = _.defaults(opts, {
+            ignoreStyle,
             ignoreElements: [],
             tolerance,
             allowViewportOverflow: false,
@@ -45,6 +46,7 @@ module.exports = (browser) => {
 
         const screenShooterOpts = {
             allowViewportOverflow: opts.allowViewportOverflow,
+            ignoreStyle: opts.ignoreStyle,
             screenshotDelay: opts.screenshotDelay
         };
 
@@ -60,19 +62,25 @@ module.exports = (browser) => {
         }
 
         const {canHaveCaret, pixelRatio} = page;
+
         const imageCompareOpts = {
             tolerance: opts.tolerance,
             antialiasingTolerance,
             canHaveCaret,
             pixelRatio,
-            compareOpts
+            compareOpts: {
+                ...compareOpts,
+                ignoreAreas: currImgInst.getIgnoreAreas()
+            }
         };
+
         const {equal, diffBounds, diffClusters, metaInfo = {}} = await Image.compare(refImg.path, currImg.path, imageCompareOpts);
+
         Object.assign(refImg, metaInfo.refImg);
 
         if (!equal) {
             const diffAreas = {diffBounds, diffClusters};
-            const opts = {canHaveCaret, diffAreas, config, emitter};
+            const opts = {canHaveCaret, diffAreas, config, emitter, ignoreAreas: currImgInst.getIgnoreAreas()};
 
             return handleImageDiff(currImg, refImg, state, opts).catch((e) => handleCaptureProcessorError(e));
         }

--- a/lib/browser/commands/assert-view/index.js
+++ b/lib/browser/commands/assert-view/index.js
@@ -13,8 +13,8 @@ const AssertViewError = require('./errors/assert-view-error');
 module.exports = (browser) => {
     const screenShooter = ScreenShooter.create(browser);
     const {publicAPI: session, config} = browser;
-    const {tolerance, antialiasingTolerance, compareOpts, screenshotDelay, system: {ignoreStyle}} = config;
-
+    const {tolerance, antialiasingTolerance, compareOpts, screenshotDelay} = config;
+    const {ignoreStyle} = compareOpts;
     const {handleNoRefImage, handleImageDiff} = getCaptureProcessors();
 
     session.addCommand('assertView', async (state, selectors, opts = {}) => {

--- a/lib/config/defaults.js
+++ b/lib/config/defaults.js
@@ -21,6 +21,7 @@ module.exports = {
     },
     calibrate: false,
     screenshotMode: 'auto',
+    ignoreStyle: 'none',
     screenshotDelay: 0,
     compositeImage: false,
     prepareBrowser: null,

--- a/lib/config/defaults.js
+++ b/lib/config/defaults.js
@@ -11,6 +11,7 @@ module.exports = {
     tolerance: 2.3,
     antialiasingTolerance: 0,
     compareOpts: {
+        ignoreStyle: 'none',
         shouldCluster: false,
         clustersSize: 10,
         stopOnFirstFail: false
@@ -21,7 +22,6 @@ module.exports = {
     },
     calibrate: false,
     screenshotMode: 'auto',
-    ignoreStyle: 'none',
     screenshotDelay: 0,
     compositeImage: false,
     prepareBrowser: null,

--- a/lib/config/defaults.js
+++ b/lib/config/defaults.js
@@ -11,7 +11,7 @@ module.exports = {
     tolerance: 2.3,
     antialiasingTolerance: 0,
     compareOpts: {
-        ignoreStyle: 'none',
+        ignoreElementsStyle: 'solid',
         shouldCluster: false,
         clustersSize: 10,
         stopOnFirstFail: false

--- a/lib/config/options.js
+++ b/lib/config/options.js
@@ -5,11 +5,13 @@ const configparser = require('gemini-configparser');
 const browserOptions = require('./browser-options');
 const defaults = require('./defaults');
 const optionsBuilder = require('./options-builder');
+const utils = require('./utils');
 
 const options = optionsBuilder(_.propertyOf(defaults));
 
 const section = configparser.section;
 const map = configparser.map;
+const is = utils.is;
 
 const coreOptions = require('gemini-core').config.options;
 
@@ -35,6 +37,17 @@ const rootSection = section(_.extend(browserOptions.getTopLevel(), {
         testsPerWorker: options.positiveIntegerOrInfinity('testsPerWorker'),
 
         diffColor: options.hexString('diffColor'),
+
+        ignoreStyle: configparser.option({
+            defaultValue: defaults.ignoreStyle,
+            validate: (value) => {
+                is('string', 'ignoreStyle')(value);
+
+                if (!_.includes(['none', 'solid', 'border'], value)) {
+                    throw new Error('"ignoreStyle" must be "none", "solid" or "border"');
+                }
+            }
+        }),
 
         tempDir: options.string('tempDir'),
 

--- a/lib/config/options.js
+++ b/lib/config/options.js
@@ -5,13 +5,11 @@ const configparser = require('gemini-configparser');
 const browserOptions = require('./browser-options');
 const defaults = require('./defaults');
 const optionsBuilder = require('./options-builder');
-const utils = require('./utils');
 
 const options = optionsBuilder(_.propertyOf(defaults));
 
 const section = configparser.section;
 const map = configparser.map;
-const is = utils.is;
 
 const coreOptions = require('gemini-core').config.options;
 
@@ -37,17 +35,6 @@ const rootSection = section(_.extend(browserOptions.getTopLevel(), {
         testsPerWorker: options.positiveIntegerOrInfinity('testsPerWorker'),
 
         diffColor: options.hexString('diffColor'),
-
-        ignoreStyle: configparser.option({
-            defaultValue: defaults.ignoreStyle,
-            validate: (value) => {
-                is('string', 'ignoreStyle')(value);
-
-                if (!_.includes(['none', 'solid', 'border'], value)) {
-                    throw new Error('"ignoreStyle" must be "none", "solid" or "border"');
-                }
-            }
-        }),
 
         tempDir: options.string('tempDir'),
 

--- a/test/lib/browser/commands/assert-view/index.js
+++ b/test/lib/browser/commands/assert-view/index.js
@@ -205,11 +205,11 @@ describe('assertView command', () => {
             });
         });
 
-        describe('should pass ignoreStyle to #ScreenShooter.capture()', () => {
+        describe('should pass ignoreElementsStyle to #ScreenShooter.capture()', () => {
             let config, browser;
 
             beforeEach(() => {
-                config = mkConfig_({system: {ignoreStyle: 'none'}});
+                config = mkConfig_({system: {ignoreElementsStyle: 'none'}});
                 browser = stubBrowser_(config);
             });
 
@@ -217,15 +217,15 @@ describe('assertView command', () => {
                 await browser.publicAPI.assertView();
 
                 assert.calledWithMatch(ScreenShooter.prototype.capture, sinon.match.any, {
-                    ignoreStyle: 'none'
+                    ignoreElementsStyle: 'none'
                 });
             });
 
             it('option is set in test', async () => {
-                await browser.publicAPI.assertView('plain', '.selector', {ignoreStyle: 'border'});
+                await browser.publicAPI.assertView('plain', '.selector', {ignoreElementsStyle: 'border'});
 
                 assert.calledWithMatch(ScreenShooter.prototype.capture, sinon.match.any, {
-                    ignoreStyle: 'border'
+                    ignoreElementsStyle: 'border'
                 });
             });
         });

--- a/test/lib/browser/commands/assert-view/index.js
+++ b/test/lib/browser/commands/assert-view/index.js
@@ -222,10 +222,10 @@ describe('assertView command', () => {
             });
 
             it('option is set in test', async () => {
-                await browser.publicAPI.assertView('plain', '.selector', {ignoreElementsStyle: 'border'});
+                await browser.publicAPI.assertView('plain', '.selector', {ignoreElementsStyle: 'solid'});
 
                 assert.calledWithMatch(ScreenShooter.prototype.capture, sinon.match.any, {
-                    ignoreElementsStyle: 'border'
+                    ignoreElementsStyle: 'solid'
                 });
             });
         });

--- a/test/lib/browser/commands/assert-view/index.js
+++ b/test/lib/browser/commands/assert-view/index.js
@@ -32,7 +32,8 @@ describe('assertView command', () => {
 
         return {
             save: sandbox.stub().named('save'),
-            getSize: sandbox.stub().named('getSize').returns(opts.size)
+            getSize: sandbox.stub().named('getSize').returns(opts.size),
+            getIgnoreAreas: sandbox.stub().named('getIgnoreAreas').returns(opts.ignoreAreas || [])
         };
     };
 
@@ -203,6 +204,31 @@ describe('assertView command', () => {
                 });
             });
         });
+
+        describe('should pass ignoreStyle to #ScreenShooter.capture()', () => {
+            let config, browser;
+
+            beforeEach(() => {
+                config = mkConfig_({system: {ignoreStyle: 'none'}});
+                browser = stubBrowser_(config);
+            });
+
+            it('option is equal the configured value by default', async () => {
+                await browser.publicAPI.assertView();
+
+                assert.calledWithMatch(ScreenShooter.prototype.capture, sinon.match.any, {
+                    ignoreStyle: 'none'
+                });
+            });
+
+            it('option is set in test', async () => {
+                await browser.publicAPI.assertView('plain', '.selector', {ignoreStyle: 'border'});
+
+                assert.calledWithMatch(ScreenShooter.prototype.capture, sinon.match.any, {
+                    ignoreStyle: 'border'
+                });
+            });
+        });
     });
 
     it('should not fail if there is no reference image', async () => {
@@ -299,6 +325,17 @@ describe('assertView command', () => {
             const config = mkConfig_({tolerance: 100, antialiasingTolerance: 200, compareOpts: {stopOnFirstFail: true}});
             const browser = stubBrowser_(config);
 
+            const currImage = stubImage_({
+                ignoreAreas: [{
+                    top: 5,
+                    left: 10,
+                    width: 40,
+                    height: 30
+                }]
+            });
+
+            ScreenShooter.prototype.capture.resolves(currImage);
+
             browser.prepareScreenshot.resolves({canHaveCaret: 'foo bar', pixelRatio: 300});
 
             await browser.publicAPI.assertView();
@@ -306,7 +343,21 @@ describe('assertView command', () => {
             assert.calledOnceWith(
                 Image.compare,
                 sinon.match.any, sinon.match.any,
-                {canHaveCaret: 'foo bar', tolerance: 100, antialiasingTolerance: 200, pixelRatio: 300, compareOpts: {stopOnFirstFail: true}}
+                {
+                    canHaveCaret: 'foo bar',
+                    tolerance: 100,
+                    antialiasingTolerance: 200,
+                    pixelRatio: 300,
+                    compareOpts: {
+                        ignoreAreas: [{
+                            top: 5,
+                            left: 10,
+                            width: 40,
+                            height: 30
+                        }],
+                        stopOnFirstFail: true
+                    }
+                }
             );
         });
 
@@ -427,12 +478,33 @@ describe('assertView command', () => {
                     const browser = stubBrowser_();
                     browser.prepareScreenshot.resolves({canHaveCaret: true});
 
+                    const image = stubImage_({
+                        ignoreAreas: [{
+                            top: 5,
+                            left: 10,
+                            width: 20,
+                            height: 30
+                        }]
+                    });
+
+                    ScreenShooter.prototype.capture.resolves(image);
                     await browser.publicAPI.assertView();
 
                     assert.calledOnceWith(
                         updateRefs.handleImageDiff,
                         sinon.match.any, sinon.match.any, sinon.match.any,
-                        {canHaveCaret: true, config: sinon.match.any, diffAreas: sinon.match.any, emitter: browser.emitter}
+                        {
+                            canHaveCaret: true,
+                            config: sinon.match.any,
+                            ignoreAreas: [{
+                                top: 5,
+                                left: 10,
+                                width: 20,
+                                height: 30
+                            }],
+                            diffAreas: sinon.match.any,
+                            emitter: browser.emitter
+                        }
                     );
                 });
             });

--- a/test/lib/browser/utils.js
+++ b/test/lib/browser/utils.js
@@ -20,7 +20,7 @@ function createBrowserConfig_(opts = {}) {
         screenshotOnRejectTimeout: 3000,
         screenshotDelay: 0,
         compareOpts: {
-            ignoreStyle: 'none'
+            ignoreElementsStyle: 'none'
         },
         windowSize: null,
         getScreenshotPath: () => '/some/path',

--- a/test/lib/browser/utils.js
+++ b/test/lib/browser/utils.js
@@ -19,7 +19,9 @@ function createBrowserConfig_(opts = {}) {
         screenshotOnReject: true,
         screenshotOnRejectTimeout: 3000,
         screenshotDelay: 0,
-        ignoreStyle: 'none',
+        compareOpts: {
+            ignoreStyle: 'none'
+        },
         windowSize: null,
         getScreenshotPath: () => '/some/path',
         system: opts.system || {},

--- a/test/lib/browser/utils.js
+++ b/test/lib/browser/utils.js
@@ -19,6 +19,7 @@ function createBrowserConfig_(opts = {}) {
         screenshotOnReject: true,
         screenshotOnRejectTimeout: 3000,
         screenshotDelay: 0,
+        ignoreStyle: 'none',
         windowSize: null,
         getScreenshotPath: () => '/some/path',
         system: opts.system || {},


### PR DESCRIPTION
Based on https://github.com/gemini-testing/gemini-core/pull/61

Added a new option `ignoreStyle`, which deals with representation of ignore areas in assertView.

That's how it's looks like (notice light-blue area, which is ignored)
![2019-09-21_01-05-06](https://user-images.githubusercontent.com/2299216/65498024-d8df1b80-dec3-11e9-9f48-7ffa48f2f54a.png)

