### PR TITLE
fix: print of left retries is replaced by print of performed retries

### DIFF
--- a/lib/reporters/base.js
+++ b/lib/reporters/base.js
@@ -29,7 +29,7 @@ module.exports = class BaseReporter {
 
     _onRetry(test) {
         this._logTestInfo(test, icons.RETRY);
-        logger.log('Will be retried. Retries left: %s', chalk.yellow(test.retriesLeft));
+        logger.log('Test retry %s failed. Will be retried', chalk.yellow(test.retriesPerformed));
     }
 
     _onTestPending(test) {

--- a/lib/runner/test-runner/insistant-test-runner.js
+++ b/lib/runner/test-runner/insistant-test-runner.js
@@ -32,7 +32,10 @@ module.exports = class InsistantTestRunner extends Runner {
         const runner = RegularTestRunner.create(this._test, browserAgent)
             .on(Events.TEST_FAIL, (data) => {
                 if (this._shouldRetry(data)) {
-                    this.emit(Events.RETRY, _.extend(data, {retriesLeft: this._retriesLeft}));
+                    this.emit(Events.RETRY, _.extend(data, {
+                        retriesLeft: this._retriesLeft,
+                        retriesPerformed: this._retriesPerformed
+                    }));
                     retry = true;
                 } else {
                     this.emit(Events.TEST_FAIL, data);


### PR DESCRIPTION
'retriesLeft' may be negative if 'shouldRetry' handler defined.

Related PR:
https://github.com/gemini-testing/hermione-retry-progressive/pull/1