### PR TITLE
fix: add timestamp to log message

### DIFF
--- a/lib/utils/logger.js
+++ b/lib/utils/logger.js
@@ -1,6 +1,10 @@
 'use strict';
 
-require('log-prefix')(() => `[${new Date().toLocaleString()}] %s`);
+require('log-prefix')(() => {
+    const date = new Date().toLocaleString('ru', {timeZone: 'Europe/Moscow', timeZoneName: 'short'});
+
+    return `[${date}] %s`;
+});
 
 module.exports = {
     log: console.log,

--- a/lib/utils/logger.js
+++ b/lib/utils/logger.js
@@ -1,7 +1,7 @@
 'use strict';
 
 require('log-prefix')(() => {
-    const date = new Date().toLocaleString('ru', {timeZone: 'Europe/Moscow', timeZoneName: 'short'});
+    const date = new Date().toLocaleString(undefined, {timeZoneName: 'short'});
 
     return `[${date}] %s`;
 });

--- a/lib/utils/logger.js
+++ b/lib/utils/logger.js
@@ -1,10 +1,6 @@
 'use strict';
 
-require('log-prefix')(() => {
-    const time = new Date().toString().split(' ').slice(4).join(' '); // e.g. "hh:mm:ss GMT+0300 (MSK)"
-
-    return `[${time}] %s`;
-});
+require('log-prefix')(() => `[${new Date().toLocaleString()}] %s`);
 
 module.exports = {
     log: console.log,

--- a/lib/utils/logger.js
+++ b/lib/utils/logger.js
@@ -1,5 +1,11 @@
 'use strict';
 
+require('log-prefix')(() => {
+    const time = new Date().toString().split(' ').slice(4).join(' '); // e.g. "hh:mm:ss GMT+0300 (MSK)"
+
+    return `[${time}] %s`;
+});
+
 module.exports = {
     log: console.log,
     warn: console.warn,

--- a/package-lock.json
+++ b/package-lock.json
@@ -4845,6 +4845,11 @@
         "lodash._reinterpolate": "~3.0.0"
       }
     },
+    "log-prefix": {
+      "version": "0.1.1",
+      "resolved": "https://registry.npmjs.org/log-prefix/-/log-prefix-0.1.1.tgz",
+      "integrity": "sha512-aP1Lst8OCdZKATqzXDN0JBissNVZuiKLyo6hOXDBxaQ1jHDsaxh2J1i5Pp0zMy6ayTKDWfUlLMXyLaQe1PJ48g=="
+    },
     "lolex": {
       "version": "2.7.5",
       "resolved": "https://registry.npmjs.org/lolex/-/lolex-2.7.5.tgz",

--- a/package.json
+++ b/package.json
@@ -42,6 +42,7 @@
     "gemini-core": "^3.8.2",
     "inherit": "^2.2.2",
     "lodash": "^4.17.4",
+    "log-prefix": "^0.1.1",
     "mocha": "~2.4.5",
     "plugins-loader": "^1.1.0",
     "q": "^2.0.0",


### PR DESCRIPTION
Добавление текущих даты и времени в каждое сообщение логов.

Пример
```
[2019-10-31 17:27:18 GMT+3]   AssertViewResults
[2019-10-31 17:27:18 GMT+3]     fromRawObject
[2019-10-31 17:27:18 GMT+3]       ✓ should create an instance form a raw object
```