### PR TITLE
feat: add ability to work with async functions in TestCollection

### DIFF
--- a/lib/test-collection.js
+++ b/lib/test-collection.js
@@ -80,6 +80,23 @@ module.exports = class TestCollection {
         }
     }
 
+    async eachTestAsync(browserId, cb) {
+        if (_.isFunction(browserId)) {
+            cb = browserId;
+            browserId = undefined;
+        }
+
+        if (browserId) {
+            for (const test of this._specs[browserId]) {
+                await cb(test, browserId);
+            }
+        } else {
+            for (const browserId of this.getBrowsers()) {
+                await this.eachTestAsync(browserId, cb);
+            }
+        }
+    }
+
     disableAll(browserId) {
         if (browserId) {
             this._specs[browserId] = this._originalSpecs[browserId].map((test) => this._mkDisabledTest(test));

--- a/test/lib/test-collection.js
+++ b/test/lib/test-collection.js
@@ -182,6 +182,34 @@ describe('test-collection', () => {
         });
     });
 
+    describe('eachTestAsync', () => {
+        it('should work with async functions ', async () => {
+            const test1 = {title: 'test1'};
+            const test2 = {title: 'test2'};
+            const collection = TestCollection.create({
+                'bro1': [test1, test2]
+            });
+
+            const tests = [];
+            await collection.eachTestAsync('bro1', async (test, browser) => {
+                return new Promise(resolve => {
+                    setTimeout(() => {
+                        tests.push({test, browser});
+                        resolve();
+                    }, 100);
+                });
+            });
+
+            assert.deepEqual(
+                tests,
+                [
+                    {test: test1, browser: 'bro1'},
+                    {test: test2, browser: 'bro1'}
+                ]
+            );
+        });
+    });
+
     describe('disableAll', () => {
         it('should disable all tests', () => {
             const test1 = {title: 'test1'};


### PR DESCRIPTION
add analogue to TestCollection.eachTest that can handle async function as a callback