### PR TITLE
fix: use sessionId in freeBrowser event between master and worker

### DIFF
--- a/lib/runner/test-runner/regular-test-runner.js
+++ b/lib/runner/test-runner/regular-test-runner.js
@@ -19,12 +19,14 @@ module.exports = class RegularTestRunner extends Runner {
     async run(workers) {
         let freeBrowserPromise;
 
-        workers.once(`worker.${this._test.id}.${this._test.browserId}.freeBrowser`, (browserState) => {
-            freeBrowserPromise = this._freeBrowser(browserState);
-        });
-
         try {
-            await this._getBrowser();
+            const browser = await this._getBrowser();
+
+            if (browser) {
+                workers.once(`worker.${browser.sessionId}.freeBrowser`, (browserState) => {
+                    freeBrowserPromise = this._freeBrowser(browserState);
+                });
+            }
 
             this._emit(Events.TEST_BEGIN);
 
@@ -79,6 +81,8 @@ module.exports = class RegularTestRunner extends Runner {
         try {
             this._browser = await this._browserAgent.getBrowser();
             this._test.sessionId = this._browser.sessionId;
+
+            return this._browser;
         } catch (error) {
             this._test.err = error;
         }

--- a/lib/worker/runner/test-runner/index.js
+++ b/lib/worker/runner/test-runner/index.js
@@ -69,7 +69,7 @@ module.exports = class TestRunner {
         const {meta, state: browserState} = browser;
         const results = {hermioneCtx, meta};
 
-        ipc.emit(`worker.${this._test.id}.${this._test.browserId}.freeBrowser`, browserState);
+        ipc.emit(`worker.${sessionId}.freeBrowser`, browserState);
         this._browserAgent.freeBrowser(browser);
 
         if (error) {

--- a/test/lib/worker/runner/test-runner/index.js
+++ b/test/lib/worker/runner/test-runner/index.js
@@ -69,8 +69,9 @@ describe('worker/runner/test-runner', () => {
         const run_ = (opts = {}) => {
             const test = opts.test || mkTest_();
             const runner = opts.runner || mkRunner_({test});
+            const sessionId = opts.sessionId || 'default-sessionId';
 
-            return runner.run({});
+            return runner.run({sessionId});
         };
 
         it('should request browser for passed session', async () => {
@@ -548,12 +549,9 @@ describe('worker/runner/test-runner', () => {
             });
 
             it('should send test related freeBrowser event on browser release', async () => {
-                const test = mkTest_({id: 'foo', browserId: 'bar'});
-                const runner = mkRunner_({test});
+                await run_({sessionId: '100500'});
 
-                await run_({runner});
-
-                assert.calledOnceWith(ipc.emit, `worker.foo.bar.freeBrowser`);
+                assert.calledOnceWith(ipc.emit, `worker.100500.freeBrowser`);
             });
         });
 
@@ -640,9 +638,6 @@ describe('worker/runner/test-runner', () => {
             });
 
             it('should send test related freeBrowser event on browser release', async () => {
-                const test = mkTest_({id: 'foo', browserId: 'bar'});
-                const runner = mkRunner_({test});
-
                 ExecutionThread.create.callsFake(({browser}) => {
                     ExecutionThread.prototype.run.callsFake(() => {
                         browser.state.baz = 'qux';
@@ -653,9 +648,9 @@ describe('worker/runner/test-runner', () => {
                     return Object.create(ExecutionThread.prototype);
                 });
 
-                await run_({runner}).catch((e) => e);
+                await run_({sessionId: '100500'}).catch((e) => e);
 
-                assert.calledOnceWith(ipc.emit, `worker.foo.bar.freeBrowser`, {baz: 'qux'});
+                assert.calledOnceWith(ipc.emit, `worker.100500.freeBrowser`, {baz: 'qux'});
             });
         });
     });


### PR DESCRIPTION
### Проблема:
При параллельном запуске одного и того же теста с использованием API метода `addTestToRun` возникает проблема с тем, что каждый тест содержит одинаковый id. И как только первый тест завершается, воркер эмитит событие `worker.TEST_ID.freeBrowser`. Это событие ловит мастер и отпускает все браузеры тестов, которые уже успели подписаться на это событие.

### Решение:
Необходимо для каждого запуска теста генерить уникальный `testRunId`. Решил реализовать это внутри `browserRunner` и строить id с использованием `browser.id` + счетчика тестов. После чего прокидываю этот уникальный id до `regularTestRunner`-а. А так же прокидываю его в воркер, который и эмитит освобождение браузера после завершения теста.

Другой вариант у меня был с помощью `Object.defineProperty` выставлять `runId` у теста, чтобы его можно было заюзать из плагина, но не было возможности переопределить. Но решил остановится на первом, так как сходу не придумал, для чего кому-то знать эту инфу + не хочется данные теста засирать.