### PR TITLE
fix: never use browser session again if it fails on initializition

### DIFF
--- a/lib/worker/runner/browser-pool.js
+++ b/lib/worker/runner/browser-pool.js
@@ -4,6 +4,7 @@ const {Calibrator} = require('gemini-core');
 const _ = require('lodash');
 const Browser = require('../../browser/existing-browser');
 const RunnerEvents = require('../constants/runner-events');
+const ipc = require('../../utils/ipc');
 
 module.exports = class BrowserPool {
     static create(config, emitter) {
@@ -19,24 +20,39 @@ module.exports = class BrowserPool {
         this._calibrator = new Calibrator();
     }
 
-    getBrowser(browserId, sessionId) {
+    async getBrowser(browserId, sessionId) {
         this._browsers[browserId] = this._browsers[browserId] || [];
 
         let browser = _.find(this._browsers[browserId], (browser) => !browser.sessionId);
 
-        if (browser) {
-            return browser.reinit(sessionId);
+        try {
+            if (browser) {
+                return await browser.reinit(sessionId);
+            }
+
+            browser = Browser.create(this._config, browserId, this._emitter);
+            this._browsers[browserId].push(browser);
+
+            await browser.init(sessionId, this._calibrator);
+            this._emitter.emit(RunnerEvents.NEW_BROWSER, browser.publicAPI, {browserId: browser.id});
+
+            return browser;
+        } catch (error) {
+            if (!browser) {
+                throw error;
+            }
+
+            browser.sessionId = sessionId;
+            browser.markAsBroken();
+            this.freeBrowser(browser);
+
+            throw Object.assign(error, {meta: browser.meta});
         }
-
-        browser = Browser.create(this._config, browserId, this._emitter);
-        this._browsers[browserId].push(browser);
-
-        return browser.init(sessionId, this._calibrator)
-            .then(() => this._emitter.emit(RunnerEvents.NEW_BROWSER, browser.publicAPI, {browserId: browser.id}))
-            .then(() => browser);
     }
 
     freeBrowser(browser) {
+        ipc.emit(`worker.${browser.sessionId}.freeBrowser`, browser.state);
+
         if (browser.state.isBroken) {
             _.pull(this._browsers[browser.id], browser);
         }

--- a/lib/worker/runner/test-runner/index.js
+++ b/lib/worker/runner/test-runner/index.js
@@ -6,7 +6,6 @@ const HookRunner = require('./hook-runner');
 const ExecutionThread = require('./execution-thread');
 const OneTimeScreenshooter = require('./one-time-screenshooter');
 const AssertViewError = require('../../../browser/commands/assert-view/errors/assert-view-error');
-const ipc = require('../../../utils/ipc');
 
 module.exports = class TestRunner {
     static create(...args) {
@@ -27,12 +26,17 @@ module.exports = class TestRunner {
 
     async run({sessionId}) {
         const test = this._test;
-        const browser = await this._browserAgent.getBrowser(sessionId);
-
-        const screenshooter = OneTimeScreenshooter.create(this._config, browser);
-
         const hermioneCtx = test.hermioneCtx || {};
 
+        let browser;
+
+        try {
+            browser = await this._browserAgent.getBrowser(sessionId);
+        } catch (e) {
+            throw Object.assign(e, {hermioneCtx});
+        }
+
+        const screenshooter = OneTimeScreenshooter.create(this._config, browser);
         const executionThread = ExecutionThread.create({test, browser, hermioneCtx, screenshooter});
         const hookRunner = HookRunner.create(test, executionThread);
 
@@ -66,10 +70,9 @@ module.exports = class TestRunner {
         }
 
         hermioneCtx.assertViewResults = assertViewResults ? assertViewResults.toRawObject() : [];
-        const {meta, state: browserState} = browser;
+        const {meta} = browser;
         const results = {hermioneCtx, meta};
 
-        ipc.emit(`worker.${sessionId}.freeBrowser`, browserState);
         this._browserAgent.freeBrowser(browser);
 
         if (error) {


### PR DESCRIPTION
### Проблема

При падении подготовки браузера в воркерах летит ошибка мимо логики про `patternsOnReject`. Ошибка про `Session timed out or not found` является именно такой ошибкой, которая, как правило, воспроизводится при подготовке браузера для теста (выставление ориентации или размера экрана). Соответственно, проблема заключается в том, что мы в сессии, от которой уже один раз получили `Session timed out or not found` продолжаем запускать тесты (по количеству выставленных `testsPerSession`), а все тесты в этой сессии падают.

### Что сделано

При любой ошибке в подготовке браузера помечаем сессию как `broken` и больше не запускаем в ней тесты.