### PR TITLE
feat: add ability to screen only visible part of the element in the viewport

### DIFF
--- a/README.md
+++ b/README.md
@@ -61,6 +61,7 @@ Hermione is a utility for integration testing of web pages using [WebdriverIO v4
       - [w3cCompatible](#w3ccompatible)
       - [strictTestsOrder](#stricttestsorder)
       - [compositeImage](#compositeimage)
+      - [screenshotMode](#screenshotMode)
   - [system](#system)
       - [debug](#debug)
       - [mochaOpts](#mochaopts)
@@ -577,6 +578,7 @@ Option name               | Description
 `w3cCompatible`           | Enable [w3c compatible](https://w3c.github.io/webdriver/) browsers support. Default value is `false`
 `strictTestsOrder`        | `hermione` will guarantee tests order in [readTests](#readtests) results. `false` by default.
 `compositeImage`          | Allows testing of regions which bottom bounds are outside of a viewport height (default: false). In the resulting screenshot the area which fits the viewport bounds will be joined with the area which is outside of the viewport height.
+`screenshotMode`          | Image capture mode
 
 #### desiredCapabilities
 **Required.** Used WebDriver [DesiredCapabilities](https://github.com/SeleniumHQ/selenium/wiki/DesiredCapabilities). For example,
@@ -710,6 +712,13 @@ Enable [w3c compatible](https://w3c.github.io/webdriver/) browsers support. Defa
 #### compositeImage
 
 Allows testing of regions which bottom bounds are outside of a viewport height (default: false). In the resulting screenshot the area which fits the viewport bounds will be joined with the area which is outside of the viewport height.
+
+#### screenshotMode
+
+Image capture mode. There are 3 allowed values for this option:
+  * `auto` (default). Mode will be obtained automatically;
+  * `fullpage`. Hermione will deal with screenshot of full page;
+  * `viewport`. Only viewport area will be used.
 
 ## system
 

--- a/README.md
+++ b/README.md
@@ -57,6 +57,7 @@ Hermione is a utility for integration testing of web pages using [WebdriverIO v4
       - [antialiasingTolerance](#antialiasingtolerance)
       - [compareOpts](#compareopts)
       - [buildDiffOpts](#builddiffopts)
+      - [assertViewOpts](#assertViewOpts)
       - [screenshotsDir](#screenshotsdir)
       - [w3cCompatible](#w3ccompatible)
       - [strictTestsOrder](#stricttestsorder)
@@ -414,7 +415,13 @@ Parameters:
  - opts (optional) `Object`:
    - ignoreElements (optional) `String|String[]` – elements, matching specified selectors will be ignored when comparing images
    - tolerance (optional) `Number` – overrides config [browsers](#browsers).[tolerance](#tolerance) value
-   - allowViewportOverflow (optional) `Boolean` – by default Hermione throws an error if element is outside the viewport's bounds, this option disables such check and makes command to screenshot the visible part of the element
+   - antialiasingTolerance (optional) `Number` – overrides config [browsers](#browsers).[antialiasingTolerance](#antialiasingTolerance) value
+   - allowViewportOverflow (optional) `Boolean` – by default Hermione throws an error if element is outside the viewport bounds. This option disables check that element is outside of the viewport left, top, right or bottom bounds. In this case only visible part of the element will be captured. But if set browser option [compositeImage](#compositeimage) with `true` value, then in the resulting screenshot will appear the whole element with not visible parts outside of the viewport.
+   - captureElementFromTop (optional) `Boolean` - ability to set capture element from the top area or from current position. In the first case viewport will be scrolled to the top of the element. Default value is `true`
+   - compositeImage (optional) `Boolean` - overrides config [browsers](#browsers).[compositeImage](#compositeImage) value
+   - screenshotDelay (optional) `Number` - overrides config [browsers](#browsers).[screenshotDelay](#screenshotDelay) value
+
+All options inside `assertView` command override the same options in the [browsers](#browsers).[assertViewOpts](#assertViewOpts).
 
 Full example:
 
@@ -422,7 +429,18 @@ Full example:
 it('some test', function() {
     return this.browser
         .url('some/url')
-        .assertView('plain', '.form', {ignoreElements: ['.link'], tolerance: 5, allowViewportOverflow: true});
+        .assertView(
+            'plain', '.form',
+            {
+                ignoreElements: ['.link'],
+                tolerance: 5,
+                antialiasingTolerance: 4,
+                allowViewportOverflow: true,
+                captureElementFromTop: true,
+                compositeImage: true,
+                screenshotDelay: 10
+            }
+        );
 });
 ```
 
@@ -574,6 +592,7 @@ Option name               | Description
 `antialiasingTolerance`   | Minimum difference in brightness between the darkest/lightest pixel (which is adjacent to the antiasing pixel) and theirs adjacent pixels. Default value is `0`.
 `compareOpts`             | Options for comparing images.
 `buildDiffOpts`           | Options for building diff image.
+`assertViewOpts`          | Options for `assertView` command, used by default.
 `screenshotsDir`          | Directory to save reference images for command `assertView`. Default dir is `hermione/screens` which is relative to `process.cwd()`.
 `w3cCompatible`           | Enable [w3c compatible](https://w3c.github.io/webdriver/) browsers support. Default value is `false`
 `strictTestsOrder`        | `hermione` will guarantee tests order in [readTests](#readtests) results. `false` by default.
@@ -696,6 +715,14 @@ buildDiffOpts: {
     ignoreAntialiasing: true,
     ignoreCaret: true
 }
+```
+
+#### assertViewOpts
+Default options used when calling [assertView](https://github.com/gemini-testing/hermione/#assertview), can be overridden by `assertView` options. Default values are:
+```javascript
+    ignoreElements: [],
+    captureElementFromTop: true,
+    allowViewportOverflow: false
 ```
 
 #### screenshotsDir

--- a/lib/browser/commands/assert-view/capture-processors/assert-refs.js
+++ b/lib/browser/commands/assert-view/capture-processors/assert-refs.js
@@ -9,8 +9,8 @@ exports.handleNoRefImage = (currImg, refImg, state) => {
 };
 
 exports.handleImageDiff = (currImg, refImg, state, opts) => {
-    const {canHaveCaret, diffAreas, config} = opts;
-    const {tolerance, antialiasingTolerance, buildDiffOpts, system: {diffColor}} = config;
+    const {tolerance, antialiasingTolerance, canHaveCaret, diffAreas, config} = opts;
+    const {buildDiffOpts, system: {diffColor}} = config;
     buildDiffOpts.ignoreCaret = buildDiffOpts.ignoreCaret && canHaveCaret;
 
     const diffOpts = {

--- a/lib/browser/commands/assert-view/index.js
+++ b/lib/browser/commands/assert-view/index.js
@@ -13,16 +13,16 @@ const AssertViewError = require('./errors/assert-view-error');
 module.exports = (browser) => {
     const screenShooter = ScreenShooter.create(browser);
     const {publicAPI: session, config} = browser;
-    const {tolerance, antialiasingTolerance, compareOpts, screenshotDelay} = config;
+    const {assertViewOpts, compareOpts, compositeImage, screenshotDelay, tolerance, antialiasingTolerance} = config;
 
     const {handleNoRefImage, handleImageDiff} = getCaptureProcessors();
 
     session.addCommand('assertView', async (state, selectors, opts = {}) => {
-        opts = _.defaults(opts, {
-            ignoreElements: [],
+        opts = _.defaults(opts, assertViewOpts, {
+            compositeImage,
+            screenshotDelay,
             tolerance,
-            allowViewportOverflow: false,
-            screenshotDelay
+            antialiasingTolerance
         });
 
         const {hermioneCtx} = session.executionContext;
@@ -37,18 +37,19 @@ module.exports = (browser) => {
             : Promise.reject(e);
 
         const page = await browser.prepareScreenshot(
-            [].concat(selectors), {ignoreSelectors: [].concat(opts.ignoreElements)}
+            [].concat(selectors),
+            {
+                ignoreSelectors: [].concat(opts.ignoreElements),
+                allowViewportOverflow: opts.allowViewportOverflow,
+                captureElementFromTop: opts.captureElementFromTop
+            }
         );
 
         const {tempOpts} = RuntimeConfig.getInstance();
         temp.attach(tempOpts);
 
-        const screenShooterOpts = {
-            allowViewportOverflow: opts.allowViewportOverflow,
-            screenshotDelay: opts.screenshotDelay
-        };
-
-        const currImgInst = await screenShooter.capture(page, screenShooterOpts);
+        const screenshoterOpts = _.pick(opts, ['allowViewportOverflow', 'compositeImage', 'screenshotDelay']);
+        const currImgInst = await screenShooter.capture(page, screenshoterOpts);
         const currImg = {path: temp.path(Object.assign(tempOpts, {suffix: '.png'})), size: currImgInst.getSize()};
         await currImgInst.save(currImg.path);
 
@@ -63,7 +64,7 @@ module.exports = (browser) => {
         const {canHaveCaret, pixelRatio} = page;
         const imageCompareOpts = {
             tolerance: opts.tolerance,
-            antialiasingTolerance,
+            antialiasingTolerance: opts.antialiasingTolerance,
             canHaveCaret,
             pixelRatio,
             compareOpts
@@ -73,9 +74,10 @@ module.exports = (browser) => {
 
         if (!equal) {
             const diffAreas = {diffBounds, diffClusters};
-            const opts = {canHaveCaret, diffAreas, config, emitter};
+            const {tolerance, antialiasingTolerance} = opts;
+            const imageDiffOpts = {tolerance, antialiasingTolerance, canHaveCaret, diffAreas, config, emitter};
 
-            return handleImageDiff(currImg, refImg, state, opts).catch((e) => handleCaptureProcessorError(e));
+            return handleImageDiff(currImg, refImg, state, imageDiffOpts).catch((e) => handleCaptureProcessorError(e));
         }
 
         hermioneCtx.assertViewResults.add({stateName: state, refImg: refImg});

--- a/lib/config/browser-options.js
+++ b/lib/config/browser-options.js
@@ -127,6 +127,18 @@ function buildBrowserOptions(defaultFactory, extra) {
 
         buildDiffOpts: options.optionalObject('buildDiffOpts'),
 
+        assertViewOpts: option({
+            defaultValue: defaultFactory('assertViewOpts'),
+            parseEnv: JSON.parse,
+            parseCli: JSON.parse,
+            validate: (value) => utils.assertOptionalObject(value, 'assertViewOpts'),
+            map: (value) => {
+                return value === defaults.assertViewOpts
+                    ? value
+                    : {...defaults.assertViewOpts, ...value};
+            }
+        }),
+
         meta: options.optionalObject('meta'),
 
         windowSize: option({

--- a/lib/config/defaults.js
+++ b/lib/config/defaults.js
@@ -19,6 +19,11 @@ module.exports = {
         ignoreAntialiasing: true,
         ignoreCaret: true
     },
+    assertViewOpts: {
+        ignoreElements: [],
+        captureElementFromTop: true,
+        allowViewportOverflow: false
+    },
     calibrate: false,
     screenshotMode: 'auto',
     screenshotDelay: 0,

--- a/package-lock.json
+++ b/package-lock.json
@@ -3543,9 +3543,9 @@
       }
     },
     "gemini-core": {
-      "version": "4.0.0",
-      "resolved": "https://registry.npmjs.org/gemini-core/-/gemini-core-4.0.0.tgz",
-      "integrity": "sha512-cHUDqWxX+B1PqiFRZTGAeRLHCulUR/0cbEEE6X5H3mpB27R9/tzyLmwa62c/V8DvNSSXDlqe+BVbQxM+k255Qg==",
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/gemini-core/-/gemini-core-5.0.0.tgz",
+      "integrity": "sha512-hg7hx17N7HI8aRhg5wBNMebO06BaVpQrbjNOBF8ptbcotn81s7WYXjMG3tdKMhczjn4bLTmsKQdV1MgZG3+SfA==",
       "requires": {
         "aliasify": "^1.9.0",
         "bluebird": "^3.4.6",
@@ -4709,9 +4709,9 @@
       "dev": true
     },
     "kind-of": {
-      "version": "6.0.2",
-      "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-6.0.2.tgz",
-      "integrity": "sha512-s5kLOcnH0XqDO+FvuaLX8DDjZ18CGFk7VygH40QoKPUQhW4e2rvM0rwUq0t8IQDOwYSeLK01U90OjzBTme2QqA=="
+      "version": "6.0.3",
+      "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-6.0.3.tgz",
+      "integrity": "sha512-dcS1ul+9tmeD95T+x28/ehLgd9mENa3LsvDTtzm3vyBEO7RPptvAD+t44WVXaUjTBRcrpFeFlC8WCruUR456hw=="
     },
     "labeled-stream-splicer": {
       "version": "2.0.2",
@@ -6710,9 +6710,9 @@
       "integrity": "sha1-Ywn04OX6kT7BxpMHrjZLSzd8nns="
     },
     "picomatch": {
-      "version": "2.1.1",
-      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-2.1.1.tgz",
-      "integrity": "sha512-OYMyqkKzK7blWO/+XZYP6w8hH0LDvkBvdvKukti+7kqYFCiEAk+gI3DWnryapc0Dau05ugGTy0foQ6mqn4AHYA=="
+      "version": "2.2.1",
+      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-2.2.1.tgz",
+      "integrity": "sha512-ISBaA8xQNmwELC7eOjqFKMESB2VIqt4PPDD0nsS95b/9dZXvVKOlz9keMSnoGGKcOHXfTvDD6WMaRoSc9UuhRA=="
     },
     "pify": {
       "version": "2.3.0",
@@ -6750,9 +6750,9 @@
       "dev": true
     },
     "png-img": {
-      "version": "2.2.1",
-      "resolved": "https://registry.npmjs.org/png-img/-/png-img-2.2.1.tgz",
-      "integrity": "sha512-08t30gTNhwf6atyP7vplsVmncHxnORXMfI449aKa8Rnhbh9mZkHouoGNE27T3fqpHdFHALoRTYkj7gms6EeCvg==",
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/png-img/-/png-img-2.3.0.tgz",
+      "integrity": "sha512-niTERtbYrszcFHdUbsM0JnKMvCUnT/5AJfozWKf8jKYf4gRoyF+xTMhgOKcM3H9rdZX9G8K+MJjPLeM90u/92w==",
       "requires": {
         "nan": "^2.14.0"
       }

--- a/package.json
+++ b/package.json
@@ -40,7 +40,7 @@
     "clear-require": "^1.0.1",
     "fs-extra": "^5.0.0",
     "gemini-configparser": "^1.0.0",
-    "gemini-core": "^4.0.0",
+    "gemini-core": "^5.0.0",
     "inherit": "^2.2.2",
     "lodash": "^4.17.4",
     "mocha": "~2.4.5",

--- a/test/lib/config/browser-options.js
+++ b/test/lib/config/browser-options.js
@@ -882,6 +882,61 @@ describe('config browser-options', () => {
         });
     });
 
+    describe('assertViewOpts', () => {
+        it('should throw error if "assertViewOpts" is not an object', () => {
+            const readConfig = {
+                browsers: {
+                    b1: mkBrowser_({assertViewOpts: 'some-string'})
+                }
+            };
+
+            Config.read.returns(readConfig);
+
+            assert.throws(() => createConfig(), Error, '"assertViewOpts" must be an object');
+        });
+
+        ['ignoreElements', 'captureElementFromTop', 'allowViewportOverflow'].forEach((option) => {
+            it(`should set "${option}" option to default value if it is not set in config`, () => {
+                const readConfig = {
+                    browsers: {
+                        b1: mkBrowser_()
+                    }
+                };
+                Config.read.returns(readConfig);
+
+                const config = createConfig();
+
+                assert.deepEqual(config.browsers.b1.assertViewOpts[option], defaults.assertViewOpts[option]);
+            });
+
+            it(`should overridde only "${option}" and use others from defaults`, () => {
+                const readConfig = {
+                    browsers: {
+                        b1: mkBrowser_({assertViewOpts: {[option]: 100500}})
+                    }
+                };
+                Config.read.returns(readConfig);
+
+                const config = createConfig();
+
+                assert.deepEqual(config.browsers.b1.assertViewOpts, {...defaults.assertViewOpts, [option]: 100500});
+            });
+        });
+
+        it('should set provided values and use others from defaults', () => {
+            const readConfig = {
+                browsers: {
+                    b1: mkBrowser_({assertViewOpts: {k1: 'v1', k2: 'v2'}})
+                }
+            };
+            Config.read.returns(readConfig);
+
+            const config = createConfig();
+
+            assert.deepEqual(config.browsers.b1.assertViewOpts, {...defaults.assertViewOpts, k1: 'v1', k2: 'v2'});
+        });
+    });
+
     [
         'calibrate',
         'screenshotOnReject',

--- a/test/lib/config/options.js
+++ b/test/lib/config/options.js
@@ -161,7 +161,7 @@ describe('config options', () => {
                 assert.equal(config.system.workers, 1);
             });
 
-            it('should be overriden from a config', () => {
+            it('should be overridden from a config', () => {
                 Config.read.returns({system: {workers: 100500}});
 
                 const config = createConfig();
@@ -251,7 +251,7 @@ describe('config options', () => {
                 assert.equal(config.system.parallelLimit, defaults.parallelLimit);
             });
 
-            it('should be overriden from a config', () => {
+            it('should be overridden from a config', () => {
                 Config.read.returns({system: {parallelLimit: 5}});
 
                 const config = createConfig();


### PR DESCRIPTION
### Что сделано:
- в команде `assertView` теперь можно установить опцию:
  - `compositeImage` - с помощью которой, можно точечно управлять снятием всего элемента или только видимой части;
  - `captureElementFromTop` - с помощью которой, можно указать, что элемент должен быть снят с самого начала или с текущей позиции;
  - `antialiasingTolerance` - раньше можно было устанавливать только `tolerance`.
- добавил опцию `assertViewOpts` на уровне браузера с помощью, которой можно установить опции используемые в каждой команде `assertView` по умолчанию, если они явно не заданы. При явном указании одной из опций внутри `assertView` она переопределит опцию из `assertViewOpts`.
- поправил создание диффа, раньше она брала значения `tolerance` и `antialiasingTolerance` из конфига, даже если значения были явно заданы через `assertView`