### PR TITLE
fix: do not decrement "retriesLeft" to negative value

### DIFF
--- a/lib/runner/test-runner/insistant-test-runner.js
+++ b/lib/runner/test-runner/insistant-test-runner.js
@@ -75,7 +75,7 @@ module.exports = class InsistantTestRunner extends Runner {
     }
 
     get _retriesLeft() {
-        return this._browserConfig.retry - this._retriesPerformed;
+        return Math.max(0, this._browserConfig.retry - this._retriesPerformed);
     }
 
     cancel() {


### PR DESCRIPTION
#### Проблема:
- воспроизводится с включенным плагином [`hermione-retry-progressive`](https://github.com/gemini-testing/hermione-retry-progressive). Данный плагин с помощью функции `shouldRetry` отправляет тест на перезапуск, если ошибка сматчилась с указанной в `errorPatterns` плагина. В этом случае, бывает возникает ситуация, что основные ретраи закончились и плагин с помощью функции `shouldRetry` еще несколько раз отправляет тест на запуск и так как hermione сама считает количество ретраев, то в логах можно увидеть следующее:
```
hermione-retry-progressive: add extra retry for test "foo" because of "bar"
Will be retried. Retries left: 0
...
hermione-retry-progressive: add extra retry for test "foo" because of "bar"
Will be retried. Retries left: -1
```

#### Решение:
- привожу значение `retriesLeft` к нулю при получении отрицательного значения. В итоге на событие `RETRY` и в функцию `shouldRetry` могут несколько раз прилететь данные с одинаковым `retriesLeft: 0`;
- пробежался по нашим плагинам использующим `shouldRetry` - проблем быть не должно.