### PR TITLE
fix: use only consistent sort functions

### DIFF
--- a/lib/hermione.js
+++ b/lib/hermione.js
@@ -74,7 +74,15 @@ module.exports = class Hermione extends BaseHermione {
 
         collection.getBrowsers().forEach((bro) => {
             if (this._config.forBrowser(bro).strictTestsOrder) {
-                collection.sortTests(bro, ({id: a}, {id: b}) => a < b ? -1 : 1);
+                collection.sortTests(bro, ({id: a}, {id: b}) => {
+                    if (a < b) {
+                        return -1;
+                    } else if (a > b) {
+                        return 1;
+                    } else {
+                        return 0;
+                    }
+                });
             }
         });
 

--- a/test/lib/hermione.js
+++ b/test/lib/hermione.js
@@ -639,7 +639,7 @@ describe('hermione', () => {
             const sortFn = TestCollection.prototype.sortTests.firstCall.args[1];
 
             assert.equal(sortFn({id: 'a'}, {id: 'b'}), -1);
-            assert.equal(sortFn({id: 'a'}, {id: 'a'}), 1);
+            assert.equal(sortFn({id: 'a'}, {id: 'a'}), 0);
             assert.equal(sortFn({id: 'b'}, {id: 'a'}), 1);
         });
 

--- a/test/lib/test-collection.js
+++ b/test/lib/test-collection.js
@@ -68,7 +68,15 @@ describe('test-collection', () => {
                 'bro2': []
             });
 
-            collection.sortTests('bro1', (a, b) => a.title < b.title);
+            collection.sortTests('bro1', (a, b) => {
+                if (a.title < b.title) {
+                    return 1;
+                } else if (a.title > b.title) {
+                    return -1;
+                } else {
+                    return 0;
+                }
+            });
 
             assert.deepEqual(collection.mapTests('bro1', (t) => t), []);
             assert.deepEqual(collection.mapTests('bro2', (t) => t), []);
@@ -84,7 +92,15 @@ describe('test-collection', () => {
                 'bro2': [test1, test2, test3]
             });
 
-            collection.sortTests('bro1', (a, b) => a.title < b.title);
+            collection.sortTests('bro1', (a, b) => {
+                if (a.title < b.title) {
+                    return 1;
+                } else if (a.title > b.title) {
+                    return -1;
+                } else {
+                    return 0;
+                }
+            });
 
             assert.deepEqual(
                 collection.mapTests('bro1', (test, browser) => ({test, browser})),
@@ -114,7 +130,15 @@ describe('test-collection', () => {
                 'bro2': [test1, test2, test3]
             });
 
-            collection.sortTests((a, b) => a.title < b.title);
+            collection.sortTests((a, b) => {
+                if (a.title < b.title) {
+                    return 1;
+                } else if (a.title > b.title) {
+                    return -1;
+                } else {
+                    return 0;
+                }
+            });
 
             assert.deepEqual(
                 collection.mapTests('bro1', (test, browser) => ({test, browser})),


### PR DESCRIPTION
Issue: tests are failing with Node 12, because the used sorting functions are not consistent (i.e. asymmetric)

Context:
https://github.com/nodejs/node/issues/24294
https://v8.dev/blog/array-sort