### PR TITLE
feat: add command history to error for timedout tests

### DIFF
--- a/README.md
+++ b/README.md
@@ -63,6 +63,7 @@ Hermione is a utility for integration testing of web pages using [WebdriverIO v4
       - [strictTestsOrder](#stricttestsorder)
       - [compositeImage](#compositeimage)
       - [screenshotMode](#screenshotMode)
+      - [saveHistoryOnTestTimeout](#saveHistoryOnTestTimeout)
   - [system](#system)
       - [debug](#debug)
       - [mochaOpts](#mochaopts)
@@ -583,7 +584,7 @@ Option name               | Description
 `shouldRetry`             | Function that determines whether to make a retry. By default returns `true `if retry attempts are available otherwise returns `false`.
 `calibrate`               | Allows to correctly capture the image. Default value is `false`.
 `screenshotPath`          | Directory to save screenshots by Webdriverio. Default value is `null`.
-`meta`                    | Additional data that can be obtained via .getMeta() method
+`meta`                    | Additional data that can be obtained via .getMeta() method.
 `windowSize`              | Browser window dimensions. Default value is `null`.
 `screenshotDelay`         | Allows to specify a delay (in milliseconds) before making any screenshot.
 `orientation`             | Browser orientation that will be set before each test run. Default value is `null`.
@@ -597,7 +598,8 @@ Option name               | Description
 `w3cCompatible`           | Enable [w3c compatible](https://w3c.github.io/webdriver/) browsers support. Default value is `false`
 `strictTestsOrder`        | `hermione` will guarantee tests order in [readTests](#readtests) results. `false` by default.
 `compositeImage`          | Allows testing of regions which bottom bounds are outside of a viewport height (default: false). In the resulting screenshot the area which fits the viewport bounds will be joined with the area which is outside of the viewport height.
-`screenshotMode`          | Image capture mode
+`screenshotMode`          | Image capture mode.
+`saveHistoryOnTestTimeout`| Save history of all executed commands in the error on test timeout.
 
 #### desiredCapabilities
 **Required.** Used WebDriver [DesiredCapabilities](https://github.com/SeleniumHQ/selenium/wiki/DesiredCapabilities). For example,

--- a/lib/config/browser-options.js
+++ b/lib/config/browser-options.js
@@ -74,6 +74,7 @@ function buildBrowserOptions(defaultFactory, extra) {
         sessionQuitTimeout: options.optionalNonNegativeInteger('sessionQuitTimeout'),
         testTimeout: options.optionalNonNegativeInteger('testTimeout'),
         waitTimeout: options.positiveInteger('waitTimeout'),
+        saveHistoryOnTestTimeout: options.boolean('saveHistoryOnTestTimeout'),
 
         screenshotOnReject: options.boolean('screenshotOnReject'),
         screenshotOnRejectTimeout: options.optionalNonNegativeInteger('screenshotOnRejectTimeout'),

--- a/lib/config/defaults.js
+++ b/lib/config/defaults.js
@@ -58,5 +58,6 @@ module.exports = {
     orientation: null,
     resetCursor: true,
     w3cCompatible: false,
-    strictTestsOrder: false
+    strictTestsOrder: false,
+    saveHistoryOnTestTimeout: false
 };

--- a/lib/worker/runner/test-runner/execution-thread.js
+++ b/lib/worker/runner/test-runner/execution-thread.js
@@ -10,6 +10,7 @@ module.exports = class ExecutionThread {
     constructor({test, browser, hermioneCtx, screenshooter}) {
         this._hermioneCtx = hermioneCtx;
         this._screenshooter = screenshooter;
+        this._saveHistoryOnTestTimeout = browser.config.saveHistoryOnTestTimeout;
 
         this._ctx = {
             browser: browser.publicAPI,
@@ -33,10 +34,7 @@ module.exports = class ExecutionThread {
         this._setExecutionContext(null);
 
         if (error) {
-            const test = this._ctx.currentTest;
-            if (!test.err) {
-                test.err = error;
-            }
+            await this._setTestErr(error);
 
             throw error;
         }
@@ -55,5 +53,24 @@ module.exports = class ExecutionThread {
 
     _setExecutionContext(context) {
         Object.getPrototypeOf(this._ctx.browser).executionContext = context;
+    }
+
+    async _setTestErr(error) {
+        const test = this._ctx.currentTest;
+
+        if (test.err) {
+            return;
+        }
+
+        if (error instanceof Promise.TimeoutError && this._saveHistoryOnTestTimeout) {
+            try {
+                const allHistory = await this._ctx.browser.getCommandHistory();
+                error.history = allHistory.map(({name, args, stack}) => ({name, args, stack}));
+            } catch (e) {
+                console.error(`Failed to get command history: ${e.message}`);
+            }
+        }
+
+        test.err = error;
     }
 };

--- a/test/lib/browser/existing-browser.js
+++ b/test/lib/browser/existing-browser.js
@@ -505,5 +505,14 @@ describe('ExistingBrowser', () => {
 
             assert.equal(browser.meta.pid, pid);
         });
+
+        it('should clear command history', () => {
+            const browser = mkBrowser_();
+            session.commandList = [{name: 'foo', args: ['bar'], stack: 'file', result: {}, timestamp: 100500}];
+
+            browser.quit();
+
+            assert.lengthOf(session.commandList, 0, 'command history is empty');
+        });
     });
 });

--- a/test/lib/config/browser-options.js
+++ b/test/lib/config/browser-options.js
@@ -942,7 +942,8 @@ describe('config browser-options', () => {
         'screenshotOnReject',
         'compositeImage',
         'resetCursor',
-        'strictTestsOrder'
+        'strictTestsOrder',
+        'saveHistoryOnTestTimeout'
     ].forEach((option) => {
         describe(option, () => {
             it('should throw an error if value is not a boolean', () => {


### PR DESCRIPTION
Add command history to error if timeout is expired after running tests.