### PR TITLE
Fixed a selector in a test-example

### DIFF
--- a/README.md
+++ b/README.md
@@ -482,7 +482,7 @@ describe('github', function() {
     it('should find hermione', function() {
         return this.browser
             .url('https://github.com/gemini-testing/hermione')
-            .getText('#readme h1')
+            .getText('#readme h1:first-child')
             .then(function(title) {
                 assert.equal(title, 'Hermione')
             });


### PR DESCRIPTION
Now it is not working and the query `#readme h1` gets a lot of items.