### PR TITLE
feat: add cli option "--require" to load external modules

### DIFF
--- a/README.md
+++ b/README.md
@@ -1072,6 +1072,7 @@ shows the following
     -r, --reporter <reporter>    test reporters
     -b, --browser <browser>      run tests only in specified browser
     -s, --set <set>              run tests only in the specified set
+    --require <module>           require a module before running hermione
     --grep <grep>                run only tests matching the pattern
     --update-refs                update screenshot references or gather them if they do not exist ("assertView" command)
     --inspect [inspect]          nodejs inspector on [=[host:]port]
@@ -1092,6 +1093,12 @@ You can choose `flat` or `plain` reporter by option `-r, --reporter`. Default is
 * `flat` – all information about failed and retried tests would be grouped by browsers at the end of the report.
 
 * `plain` – information about fails and retries would be placed after each test.
+
+## Require modules
+
+Using `--require` option you can load external modules, which exists in your local machine, before running hermione. This is useful for:
+- compilers such as TypeScript via [ts-node](https://www.npmjs.com/package/ts-node) (using `--require ts-node/register`) or Babel via [@babel/register](https://www.npmjs.com/package/@babel/register) (using `--require @babel/register`);
+- loaders such as ECMAScript modules via [esm](https://www.npmjs.com/package/esm).
 
 ## Overriding settings
 

--- a/lib/cli/index.js
+++ b/lib/cli/index.js
@@ -33,6 +33,7 @@ exports.run = () => {
         .option('-r, --reporter <reporter>', 'test reporters', collect)
         .option('-b, --browser <browser>', 'run tests only in specified browser', collect)
         .option('-s, --set <set>', 'run tests only in the specified set', collect)
+        .option('--require <module>', 'require module', collect)
         .option('--grep <grep>', 'run only tests matching the pattern')
         .option('--update-refs', 'update screenshot references or gather them if they do not exist ("assertView" command)')
         .option('--inspect [inspect]', 'nodejs inspector on [=[host:]port]')
@@ -40,6 +41,8 @@ exports.run = () => {
         .arguments('[paths...]')
         .action(async (paths) => {
             try {
+                handleRequires(program.require);
+
                 const isTestsSuccess = await hermione.run(paths, {
                     reporters: program.reporter || defaults.reporters,
                     browsers: program.browser,
@@ -76,4 +79,8 @@ function preparseOption(program, option) {
 
     configFileParser.parse(process.argv);
     return configFileParser[option];
+}
+
+function handleRequires(requires = []) {
+    requires.forEach((module) => require(module));
 }

--- a/test/lib/cli/index.js
+++ b/test/lib/cli/index.js
@@ -3,6 +3,7 @@
 const {Command} = require('@gemini-testing/commander');
 const q = require('q');
 const _ = require('lodash');
+const proxyquire = require('proxyquire');
 const hermioneCli = require('lib/cli');
 const info = require('lib/cli/info');
 const defaults = require('lib/config/defaults');
@@ -61,6 +62,21 @@ describe('cli', () => {
         await actionPromise;
 
         assert.calledOnce(Hermione.create);
+    });
+
+    it('should require modules specified in "require" option', async () => {
+        const fooRequire = sandbox.stub().returns({});
+
+        const stubHermioneCli = proxyquire('lib/cli', {
+            foo: (() => fooRequire())()
+        });
+
+        onParse((parser) => parser.require = ['foo']);
+
+        stubHermioneCli.run();
+        await actionPromise;
+
+        assert.calledOnce(fooRequire);
     });
 
     it('should create Hermione without config by default', async () => {


### PR DESCRIPTION
### What is done:
- add new cli option `--require` to load external modules
- ~~break backward compatibility in order to be able to use short option `-r` for `--require` and not for `--reporter`. This is done because in node, mocha, webpack, ... this short option used exactly for require other modules.~~