### PR TITLE
feat: add browser option "waitOrientationChange"

### DIFF
--- a/README.md
+++ b/README.md
@@ -52,6 +52,7 @@ Hermione is a utility for integration testing of web pages using [WebdriverIO v4
       - [windowSize](#windowsize)
       - [screenshotDelay](#screenshotdelay)
       - [orientation](#orientation)
+      - [waitOrientationChange](#waitOrientationChange)
       - [resetCursor](#resetcursor)
       - [tolerance](#tolerance)
       - [antialiasingTolerance](#antialiasingtolerance)
@@ -589,6 +590,7 @@ Option name               | Description
 `windowSize`              | Browser window dimensions. Default value is `null`.
 `screenshotDelay`         | Allows to specify a delay (in milliseconds) before making any screenshot.
 `orientation`             | Browser orientation that will be set before each test run. Default value is `null`.
+`waitOrientationChange`   | Allows to wait until screen orientation is changed. Default value is `true`.
 `resetCursor`             | Allows to configure whether to move mouse cursor to `body` coordinates `(0, 0)` before each test run.
 `tolerance`               | Maximum allowed [CIEDE2000](http://en.wikipedia.org/wiki/Color_difference#CIEDE2000) difference between colors. Default value is `2.3`.
 `antialiasingTolerance`   | Minimum difference in brightness between the darkest/lightest pixel (which is adjacent to the antiasing pixel) and theirs adjacent pixels. Default value is `0`.
@@ -693,6 +695,9 @@ Allows to specify a delay (in milliseconds) before making any screenshot. This i
 
 #### orientation
 Browser orientation (`landscape`, `portrait`) that will be set before each test run. It is necessary in order to return the browser orientation to the default state after test execution in which orientation is changed. Default value is `null`.
+
+#### waitOrientationChange
+Allows to wait until screen orientation is changed. Works inside `webdriverio` commands `orientation` and `setOrientation`. This option guarantee that screen rotated before the next command will start to execute. Default value is `true`.
 
 #### resetCursor
 Allows to configure whether to move mouse cursor to `body` coordinates `(0, 0)` before each test run. This can be useful to escape cases when a default position of a cursor affects your tests. We recommend to set this option *truthy* value for desktop browsers and *falsey* for mobile devices. Default value is `true`.

--- a/lib/browser/commands/orientation/index.js
+++ b/lib/browser/commands/orientation/index.js
@@ -15,7 +15,11 @@ module.exports = (browser) => {
             .then((initialBodyWidth) => {
                 return baseOrientationFn(orientation)
                     .then((result) => {
-                        if (result.value.match(/Already in/)) {
+                        if (!config.waitOrientationChange) {
+                            return result;
+                        }
+
+                        if (typeof result.value === 'string' && result.value.match(/Already in/)) {
                             return result;
                         }
 

--- a/lib/config/browser-options.js
+++ b/lib/config/browser-options.js
@@ -187,6 +187,8 @@ function buildBrowserOptions(defaultFactory, extra) {
             }
         }),
 
+        waitOrientationChange: options.boolean('waitOrientationChange'),
+
         resetCursor: options.boolean('resetCursor')
     });
 }

--- a/lib/config/defaults.js
+++ b/lib/config/defaults.js
@@ -56,6 +56,7 @@ module.exports = {
     windowSize: null,
     tempDir: '',
     orientation: null,
+    waitOrientationChange: true,
     resetCursor: true,
     w3cCompatible: false,
     strictTestsOrder: false,

--- a/test/lib/browser/commands/orientation/index.js
+++ b/test/lib/browser/commands/orientation/index.js
@@ -31,6 +31,15 @@ describe('orientation command', () => {
         assert.equal(baseOrientationFn.lastCall.args.length, 0);
     });
 
+    it('should not throw if orientation does not return current state', async () => {
+        const baseOrientationFn = session.orientation;
+        baseOrientationFn.resolves({value: null});
+
+        mkBrowser_();
+
+        await assert.isFulfilled(session.orientation('portrait'));
+    });
+
     it('should return current orientation if command was called without arguments', async () => {
         const baseOrientationFn = session.orientation;
         baseOrientationFn.resolves({value: 'portrait'});
@@ -73,6 +82,17 @@ describe('orientation command', () => {
         const orientation = await session.orientation('portrait');
 
         assert.deepEqual(orientation, {value: 'portrait'});
+    });
+
+    it('should not wait for orientation change if option "waitOrientationChange" set to false', async () => {
+        const baseOrientationFn = session.orientation;
+        baseOrientationFn.resolves({value: 'portrait'});
+
+        mkBrowser_({waitOrientationChange: false});
+
+        await session.orientation('portrait');
+
+        assert.notCalled(session.waitUntil);
     });
 
     it('should wait for orientation change', async () => {

--- a/test/lib/browser/utils.js
+++ b/test/lib/browser/utils.js
@@ -24,7 +24,8 @@ function createBrowserConfig_(opts = {}) {
         system: opts.system || {},
         buildDiffOpts: {
             ignoreCaret: true
-        }
+        },
+        waitOrientationChange: true
     });
 
     return {

--- a/test/lib/config/browser-options.js
+++ b/test/lib/config/browser-options.js
@@ -943,7 +943,8 @@ describe('config browser-options', () => {
         'compositeImage',
         'resetCursor',
         'strictTestsOrder',
-        'saveHistoryOnTestTimeout'
+        'saveHistoryOnTestTimeout',
+        'waitOrientationChange'
     ].forEach((option) => {
         describe(option, () => {
             it('should throw an error if value is not a boolean', () => {


### PR DESCRIPTION
- this option allows to disable wait until the orientation changes;
- currently it is necessary for ios safari;