### PR TITLE
feat: add dataUrl command

### DIFF
--- a/lib/browser/existing-browser.js
+++ b/lib/browser/existing-browser.js
@@ -32,6 +32,7 @@ module.exports = class ExistingBrowser extends Browser {
 
     _addCommands() {
         this._addMetaAccessCommands(this._session);
+        this._addDataUrlCommand(this._session);
         this._decorateUrlMethod(this._session);
 
         commandsList.forEach((command) => require(`./commands/${command}`)(this));
@@ -42,6 +43,16 @@ module.exports = class ExistingBrowser extends Browser {
     _addMetaAccessCommands(session) {
         session.addCommand('setMeta', (key, value) => this._meta[key] = value);
         session.addCommand('getMeta', (key) => key ? this._meta[key] : this._meta);
+    }
+
+    _addDataUrlCommand(session) {
+        const baseUrlFn = session.url;
+        session.addCommand('dataUrl', function(url) {
+            if (!url.startsWith('data:')) {
+                throw new Error(`"dataUrl" command expects raw Data URLs (${url} is passed)`);
+            }
+            baseUrlFn.apply(this, arguments);
+        });
     }
 
     _decorateUrlMethod(session) {

--- a/test/lib/browser/existing-browser.js
+++ b/test/lib/browser/existing-browser.js
@@ -70,6 +70,35 @@ describe('ExistingBrowser', () => {
             });
         });
 
+        describe('dataUrl command', () => {
+            it('should throw when not data url is passed', () => {
+                mkBrowser_({baseUrl: 'http://some.domain.org/root'});
+
+                assert.throws(() => {
+                    session.dataUrl('/foo/bar?baz=qux');
+                }, '"dataUrl" command expects raw Data URLs (/foo/bar?baz=qux is passed)');
+            });
+
+            it('should call base `url` method without modifications', () => {
+                const baseUrlFn = session.url;
+
+                mkBrowser_({baseUrl: 'http://some.domain.org/root'});
+
+                session.dataUrl('data:,Hello%2C%20World!');
+
+                assert.calledWithExactly(baseUrlFn, 'data:,Hello%2C%20World!');
+                assert.calledOn(baseUrlFn, session);
+            });
+
+            it('should not modify browser meta', () => {
+                const browser = mkBrowser_({baseUrl: 'http://some.domain.org/root'});
+
+                session.dataUrl('data:,Hello%2C%20World!');
+
+                assert.equal(browser.meta.url, undefined);
+            });
+        });
+
         describe('url decorator', () => {
             it('should force rewrite base `url` method', () => {
                 mkBrowser_();

--- a/typings/webdriverio/index.d.ts
+++ b/typings/webdriverio/index.d.ts
@@ -7,6 +7,8 @@ declare namespace WebdriverIO {
 
         setMeta(key: string, value: unknown): Client<T>;
 
+        dataUrl(url?: string): Client<T>;
+
         extendOptions(opts: { [name: string]: unknown }): Client<T>;
 
         /**


### PR DESCRIPTION
Переопределения команды `url` не учитывают возможность установки в адресную строку запросов, которые не будут отправляться на сервер, например, по data-url протоколу. Исправлять все эти команды будет значительно сложнее, чем завести специальную команду, предназначенную для этого. Для того чтобы подобной командой не злоупотребляли, она ограничена поддержкой только data-урлов.
