### PR TITLE
feat: added 'hasBrowserVersionOverwriten' property for test

### DIFF
--- a/lib/test-reader/browser/commands/version.js
+++ b/lib/test-reader/browser/commands/version.js
@@ -9,7 +9,10 @@ module.exports = class VersionCommand extends BaseCommand {
     }
 
     execute(browserVersionToSet) {
-        this._oneTimeHandler = (test) => test.browserVersion = browserVersionToSet;
+        this._oneTimeHandler = (test) => {
+            test.browserVersion = browserVersionToSet;
+            test.hasBrowserVersionOverwritten = true;
+        };
     }
 
     handleTest(test = {}) {

--- a/test/lib/test-reader/browser/commands/version.js
+++ b/test/lib/test-reader/browser/commands/version.js
@@ -11,7 +11,7 @@ describe('VersionCommand', () => {
             command.execute('v1.2');
             command.handleTest(test);
 
-            assert.deepEqual(test, {browserVersion: 'v1.2'});
+            assert.deepEqual(test, {browserVersion: 'v1.2', hasBrowserVersionOverwritten: true});
         });
 
         it('should apply the version once', () => {
@@ -34,7 +34,7 @@ describe('VersionCommand', () => {
             command.execute('v1.3');
             command.handleTest(test);
 
-            assert.deepEqual(test, {browserVersion: 'v1.3'});
+            assert.deepEqual(test, {browserVersion: 'v1.3', hasBrowserVersionOverwritten: true});
         });
     });
 
@@ -49,8 +49,8 @@ describe('VersionCommand', () => {
             command.handleTest(test1);
             command.handleTest(test2);
 
-            assert.deepEqual(test1, {browserVersion: 'v1.2'});
-            assert.deepEqual(test2, {browserVersion: 'v1.2'});
+            assert.deepEqual(test1, {browserVersion: 'v1.2', hasBrowserVersionOverwritten: true});
+            assert.deepEqual(test2, {browserVersion: 'v1.2', hasBrowserVersionOverwritten: true});
         });
 
         it('should apply the version for a nested suite', () => {
@@ -63,7 +63,7 @@ describe('VersionCommand', () => {
             command.handleSuite();
             command.handleTest(test);
 
-            assert.deepEqual(test, {browserVersion: 'v1.2'});
+            assert.deepEqual(test, {browserVersion: 'v1.2', hasBrowserVersionOverwritten: true});
         });
 
         it('should apply the version for a suite after a test version has applied', () => {
@@ -76,7 +76,7 @@ describe('VersionCommand', () => {
             command.handleTest();
             command.handleTest(test);
 
-            assert.deepEqual(test, {browserVersion: 'v1.2'});
+            assert.deepEqual(test, {browserVersion: 'v1.2', hasBrowserVersionOverwritten: true});
         });
     });
 });


### PR DESCRIPTION
Added property for a test to be able to determine if a browser version of the test was overwritten from the native helper `browser().version()`.