### PR TITLE
chore: update gemini-core@6.1.2

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -2640,23 +2640,28 @@
       "integrity": "sha512-GJCAeDBKfREgkBtgrYSf9hQy9kTb3helv0zGdzqhM7iAkW8FA/ZF97VQDbwFiwIT8MQLLOe5VlPZOEvZAqtUAQ=="
     },
     "elliptic": {
-      "version": "6.5.3",
-      "resolved": "https://registry.npmjs.org/elliptic/-/elliptic-6.5.3.tgz",
-      "integrity": "sha512-IMqzv5wNQf+E6aHeIqATs0tOLeOTwj1QKbRcS3jBbYkl5oLAserA8yJTT7/VyHUYG91PRmPyeQDObKLPpeS4dw==",
+      "version": "6.5.4",
+      "resolved": "https://registry.npmjs.org/elliptic/-/elliptic-6.5.4.tgz",
+      "integrity": "sha512-iLhC6ULemrljPZb+QutR5TQGB+pdW6KGD5RSegS+8sorOZT+rdQFbsQFJgvN3eRqNALqJer4oQ16YvJHlU8hzQ==",
       "requires": {
-        "bn.js": "^4.4.0",
-        "brorand": "^1.0.1",
+        "bn.js": "^4.11.9",
+        "brorand": "^1.1.0",
         "hash.js": "^1.0.0",
-        "hmac-drbg": "^1.0.0",
-        "inherits": "^2.0.1",
-        "minimalistic-assert": "^1.0.0",
-        "minimalistic-crypto-utils": "^1.0.0"
+        "hmac-drbg": "^1.0.1",
+        "inherits": "^2.0.4",
+        "minimalistic-assert": "^1.0.1",
+        "minimalistic-crypto-utils": "^1.0.1"
       },
       "dependencies": {
         "bn.js": {
           "version": "4.11.9",
           "resolved": "https://registry.npmjs.org/bn.js/-/bn.js-4.11.9.tgz",
           "integrity": "sha512-E6QoYqCKZfgatHTdHzs1RRKP7ip4vvm+EyRUeE2RF0NblwVvb0p6jSVeNTOFxPn26QXN2o6SMfNxKp6kU8zQaw=="
+        },
+        "inherits": {
+          "version": "2.0.4",
+          "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.4.tgz",
+          "integrity": "sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ=="
         }
       }
     },
@@ -3117,9 +3122,9 @@
       "integrity": "sha1-ewUhjd+WZ79/Nwv3/bLLFf3Qqkk="
     },
     "fast-glob": {
-      "version": "3.2.4",
-      "resolved": "https://registry.npmjs.org/fast-glob/-/fast-glob-3.2.4.tgz",
-      "integrity": "sha512-kr/Oo6PX51265qeuCYsyGypiO5uJFgBS0jksyG7FUeCyQzNwYnzrNIMR1NXfkZXsMYXYLRAHgISHBz8gQcxKHQ==",
+      "version": "3.2.5",
+      "resolved": "https://registry.npmjs.org/fast-glob/-/fast-glob-3.2.5.tgz",
+      "integrity": "sha512-2DtFcgT68wiTTiwZ2hNdJfcHNke9XOfnwmBRWXhmeKM8rF0TGwmC/Qto3S7RoZKp5cilZbxzO5iTNTQsJ+EeDg==",
       "requires": {
         "@nodelib/fs.stat": "^2.0.2",
         "@nodelib/fs.walk": "^1.2.3",
@@ -3146,9 +3151,9 @@
       "integrity": "sha512-Utm6CdzT+6xsDk2m8S6uL8VHxNwI6Jub+e9NYTcAms28T84pTa25GJQV9j0CY0N1rM8hK4x6grpF2BQf+2qwVA=="
     },
     "fastq": {
-      "version": "1.10.0",
-      "resolved": "https://registry.npmjs.org/fastq/-/fastq-1.10.0.tgz",
-      "integrity": "sha512-NL2Qc5L3iQEsyYzweq7qfgy5OtXCmGzGvhElGEd/SoFWEMOEczNh5s5ocaF01HDetxz+p8ecjNPA6cZxxIHmzA==",
+      "version": "1.10.1",
+      "resolved": "https://registry.npmjs.org/fastq/-/fastq-1.10.1.tgz",
+      "integrity": "sha512-AWuv6Ery3pM+dY7LYS8YIaCiQvUaos9OB1RyNgaOWnaX+Tik7Onvcsf8x8c+YtDeT0maYLniBip2hox5KtEXXA==",
       "requires": {
         "reusify": "^1.0.4"
       }
@@ -3365,9 +3370,9 @@
       }
     },
     "gemini-core": {
-      "version": "6.1.1",
-      "resolved": "https://registry.npmjs.org/gemini-core/-/gemini-core-6.1.1.tgz",
-      "integrity": "sha512-27srHMfNqqw5u7OnZPu5slNeo4iAVzX11W+88wuPLN1M3UW4xqiI/SrXH3YJ8m5DtrDgwDzsl8B8k/zmZrFxSQ==",
+      "version": "6.1.2",
+      "resolved": "https://registry.npmjs.org/gemini-core/-/gemini-core-6.1.2.tgz",
+      "integrity": "sha512-E1CnXi2bmTAx2zyXO/8xME+/5iyvK0brPYQCirDaMYIykRx7uaCMDLgQjQxB6dvdyyjIKELkyn8rFej0o5ckZA==",
       "requires": {
         "aliasify": "^1.9.0",
         "bluebird": "^3.4.6",
@@ -3376,7 +3381,7 @@
         "gemini-configparser": "^1.0.0",
         "glob-extra": "^5.0.0",
         "lodash": "^4.17.15",
-        "looks-same": "^7.2.4",
+        "looks-same": "^7.3.0",
         "micromatch": "^4.0.2",
         "png-img": "^3.3.0",
         "sizzle": "^2.3.3",
@@ -4563,9 +4568,9 @@
       "integrity": "sha1-MKCy2jj3N3DoKUoNIuZiXtd9AJc="
     },
     "looks-same": {
-      "version": "7.2.4",
-      "resolved": "https://registry.npmjs.org/looks-same/-/looks-same-7.2.4.tgz",
-      "integrity": "sha512-PUm/63gRQh4i7K85ZDhRjQCmg5tU9OwlO5O2AdgWJWYC/EhdCMCWJH2ozLfRJU63Dz9B/J/ZicKevkyOIaxxRg==",
+      "version": "7.3.0",
+      "resolved": "https://registry.npmjs.org/looks-same/-/looks-same-7.3.0.tgz",
+      "integrity": "sha512-pOfwX2d0frSt7H1cuBjDbw9Kry5QwkrFri0qJvLwV1sI0cbWkwYkpd7fF7SqSIfYKAZhgeB8PM3fyhUYz7xgqA==",
       "requires": {
         "color-diff": "^1.1.0",
         "concat-stream": "^1.6.2",

--- a/package.json
+++ b/package.json
@@ -44,7 +44,7 @@
     "clear-require": "^1.0.1",
     "fs-extra": "^5.0.0",
     "gemini-configparser": "^1.0.0",
-    "gemini-core": "^6.1.1",
+    "gemini-core": "^6.1.2",
     "inherit": "^2.2.2",
     "json-stringify-safe": "^5.0.1",
     "lodash": "^4.17.4",


### PR DESCRIPTION
Up gemini-core@6.1.2 in which was looks-same updated to 7.3.0 in which add ability to compare images by buffers before parse them.