### PR TITLE
Introducing the urlHttpTimeout config option

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,6 +38,7 @@ Hermione is a utility for integration testing of web pages using [WebdriverIO v4
     - [gridUrl](#gridurl)
     - [baseUrl](#baseurl)
     - [httpTimeout](#httptimeout)
+    - [urlHttpTimeout](#urlhttptimeout)
     - [pageLoadTimeout](#pageloadtimeout)
     - [sessionRequestTimeout](#sessionrequesttimeout)
     - [sessionQuitTimeout](#sessionquittimeout)
@@ -613,6 +614,7 @@ Option name               | Description
 `baseUrl`                 | Base service-under-test URL. Default value is `http://localhost`.
 `waitTimeout`             | Timeout for web page event. Default value is `1000` ms.
 `httpTimeout`             | Timeout for any requests to Selenium server. Default value is `90000` ms.
+`urlHttpTimeout`          | Timeout for `/url` request to Selenium server. Default value is `httpTimeout`.
 `pageLoadTimeout`         | Timeout for the page loading to complete. Default value is `300000` ms.
 `sessionRequestTimeout`   | Timeout for getting a browser session. Default value is `httpTimeout`.
 `sessionQuitTimeout`      | Timeout for quitting a session. Default value is `httpTimeout`.
@@ -665,6 +667,10 @@ Base service-under-test URL. Default value is `http://localhost`.
 
 #### httpTimeout
 Timeout for any requests to Selenium server. Default value is `90000` ms.
+
+#### urlHttpTimeout
+Timeout for `/url` request to Selenium server. Default value is `httpTimeout`.
+It may be useful when opening url takes a long time (for example a lot of logic is executed in middlewares), and you don't want to increase timeout for other commands.
 
 #### pageLoadTimeout
 Timeout for the page loading to complete. Default value is `300000` ms.

--- a/lib/browser/existing-browser.js
+++ b/lib/browser/existing-browser.js
@@ -51,15 +51,24 @@ module.exports = class ExistingBrowser extends Browser {
     _decorateUrlMethod(session) {
         const baseUrlFn = session.url.bind(session);
 
-        session.addCommand('url', (uri) => {
+        session.addCommand('url', async (uri) => {
             if (!uri) {
                 return baseUrlFn(uri);
             }
 
             const newUri = this._resolveUrl(uri);
             this._meta.url = newUri;
-            return baseUrlFn(newUri)
-                .then((res) => this._clientBridge ? this._clientBridge.call('resetZoom').then(() => res) : res);
+
+            if (this._config.urlHttpTimeout) {
+                this.setHttpTimeout(this._config.urlHttpTimeout);
+            }
+
+            let result = await baseUrlFn(newUri);
+            if (this._config.urlHttpTimeout) {
+                this.restoreHttpTimeout();
+            }
+
+            return this._clientBridge ? this._clientBridge.call('resetZoom').then(() => result) : result;
         }, true); // overwrite original `url` method
     }
 

--- a/lib/config/browser-options.js
+++ b/lib/config/browser-options.js
@@ -69,6 +69,7 @@ function buildBrowserOptions(defaultFactory, extra) {
         shouldRetry: options.optionalFunction('shouldRetry'),
 
         httpTimeout: options.nonNegativeInteger('httpTimeout'),
+        urlHttpTimeout: options.optionalNonNegativeInteger('urlHttpTimeout'),
         pageLoadTimeout: options.optionalNonNegativeInteger('pageLoadTimeout'),
         sessionRequestTimeout: options.optionalNonNegativeInteger('sessionRequestTimeout'),
         sessionQuitTimeout: options.optionalNonNegativeInteger('sessionQuitTimeout'),

--- a/lib/config/defaults.js
+++ b/lib/config/defaults.js
@@ -32,6 +32,7 @@ module.exports = {
     prepareEnvironment: null,
     waitTimeout: 1000,
     httpTimeout: 90000,
+    urlHttpTimeout: null,
     pageLoadTimeout: null,
     sessionRequestTimeout: null,
     sessionQuitTimeout: null,

--- a/test/lib/browser/existing-browser.js
+++ b/test/lib/browser/existing-browser.js
@@ -142,6 +142,56 @@ describe('ExistingBrowser', () => {
 
                 assert.notProperty(browser.meta, 'url');
             });
+
+            describe('"urlHttpTimeout" is set', () => {
+                let browser;
+                let baseUrlFn;
+
+                beforeEach(() => {
+                    baseUrlFn = session.url;
+
+                    browser = mkBrowser_({urlHttpTimeout: 1234});
+                    browser.setHttpTimeout = sinon.stub().named('setHttpTimeout');
+                    browser.restoreHttpTimeout = sinon.stub().named('restoreHttpTimeout');
+                });
+
+                it('should set http timeout for url command before calling it', async () => {
+                    await session.url('/some/url');
+
+                    assert.calledOnceWith(browser.setHttpTimeout, 1234);
+                    assert.callOrder(browser.setHttpTimeout, baseUrlFn);
+                });
+
+                it('should restore http timeout after calling the url command', async () => {
+                    await session.url('/some/url');
+
+                    assert.calledOnce(browser.restoreHttpTimeout);
+                    assert.calledWithExactly(browser.restoreHttpTimeout);
+                    assert.callOrder(baseUrlFn, browser.restoreHttpTimeout);
+                });
+            });
+
+            describe('"urlHttpTimeout" is not set', () => {
+                let browser;
+
+                beforeEach(() => {
+                    browser = mkBrowser_();
+                    browser.setHttpTimeout = sinon.stub().named('setHttpTimeout');
+                    browser.restoreHttpTimeout = sinon.stub().named('restoreHttpTimeout');
+                });
+
+                it('should not set http timeout for url command', async () => {
+                    await session.url();
+
+                    assert.notCalled(browser.setHttpTimeout);
+                });
+
+                it('should not restore http timeout', async () => {
+                    await session.url();
+
+                    assert.notCalled(browser.restoreHttpTimeout);
+                });
+            });
         });
 
         describe('Camera', () => {

--- a/test/lib/config/browser-options.js
+++ b/test/lib/config/browser-options.js
@@ -531,7 +531,7 @@ describe('config browser-options', () => {
 
     [
         'retry', 'httpTimeout', 'sessionRequestTimeout', 'sessionQuitTimeout',
-        'screenshotOnRejectTimeout', 'screenshotDelay', 'pageLoadTimeout', 'testTimeout'
+        'screenshotOnRejectTimeout', 'screenshotDelay', 'pageLoadTimeout', 'testTimeout', 'urlHttpTimeout'
     ].forEach((option) => {
         describe(`${option}`, () => {
             it(`should throw error if ${option} is not a number`, () => {

--- a/typings/index.d.ts
+++ b/typings/index.d.ts
@@ -317,6 +317,7 @@ declare namespace Hermione {
         retry: number;
         shouldRetry(testInfo: {ctx: Test, retriesLeft: number }): boolean | null;
         httpTimeout: number;
+        urlHttpTimeout: number | null;
         pageLoadTimeout: number | null;
         sessionRequestTimeout: number | null;
         sessionQuitTimeout: number | null;


### PR DESCRIPTION
This PR introduces new config option - `urlHttpTimeout` which is used as http timeout for requests to Selenium server while executing the `url` command. Might be helpful when `/url` requests are slow and require an increased timeout, but one doesn't want to affect anything else.