### PR TITLE
fix: set timeout for execution screenshot on reject

### DIFF
--- a/lib/worker/runner/test-runner/one-time-screenshooter.js
+++ b/lib/worker/runner/test-runner/one-time-screenshooter.js
@@ -1,6 +1,7 @@
 'use strict';
 
 const _ = require('lodash');
+const Promise = require('bluebird');
 const {Image} = require('gemini-core');
 const logger = require('../../../utils/logger');
 
@@ -21,10 +22,16 @@ module.exports = class OneTimeScreenshooter {
         }
 
         this._screenshotTaken = true;
-        this._browser.setHttpTimeout(this._config.screenshotOnRejectTimeout);
+
+        const screenshotOnRejectTimeout = this._config.screenshotOnRejectTimeout || this._config.httpTimeout;
+        this._browser.setHttpTimeout(screenshotOnRejectTimeout);
 
         try {
-            const {value: base64} = await this._browser.publicAPI.screenshot();
+            const msg = `timed out after ${screenshotOnRejectTimeout} ms`;
+            const {value: base64} = await Promise.method(this._browser.publicAPI.screenshot)
+                .call(this._browser.publicAPI)
+                .timeout(screenshotOnRejectTimeout, msg);
+
             const size = Image.fromBase64(base64).getSize();
 
             error = _.extend(error, {screenshot: {base64, size}});


### PR DESCRIPTION
The example with hermione-test which hangs on execution:
```
it('test1', async function() {
  this.browser.addCommand('screenshot', () => {
    return new Promise((resolve, reject) => {
      console.log('BEFORE REJECT1!!!');
      reject(`some error!!!`);
    });
  }, true);
  
  await this.browser.foo();
});
```

This test will try to take screenshot on reject because `foo` method does not exists in `browser` but it will hangs forever because wdio@4 has custom promises implementation which does not work in that case correctly.

To fix this problem add timeout for execution screenshot on reject. Moreover this problem does not reproduce with wdio@6.