### PR TITLE
fix: use new typings from webdriverio

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -309,14 +309,6 @@
         "@types/node": "*"
       }
     },
-    "@types/webdriverio": {
-      "version": "4.13.3",
-      "resolved": "https://registry.npmjs.org/@types/webdriverio/-/webdriverio-4.13.3.tgz",
-      "integrity": "sha512-AfSQM1xTO9Ax+u9uSQPDuw69DQ0qA2RMoKHn86jCgWNcwKVUjGMSP4sfSl3JOfcZN8X/gWvn7znVPp2/g9zcJA==",
-      "requires": {
-        "@types/node": "*"
-      }
-    },
     "@types/which": {
       "version": "1.3.2",
       "resolved": "https://registry.npmjs.org/@types/which/-/which-1.3.2.tgz",
@@ -340,6 +332,16 @@
         "@wdio/types": "7.0.7",
         "deepmerge": "^4.0.0",
         "glob": "^7.1.2"
+      },
+      "dependencies": {
+        "@wdio/types": {
+          "version": "7.0.7",
+          "resolved": "https://registry.npmjs.org/@wdio/types/-/types-7.0.7.tgz",
+          "integrity": "sha512-4UiQevmw9is81RC8ZA6+HTsDAc/m4MGsWZ7UHBeLQGbpzLixexXbluZxF85xWsgFOanW20wVahfsU63gQ5byvQ==",
+          "requires": {
+            "got": "^11.8.1"
+          }
+        }
       }
     },
     "@wdio/logger": {
@@ -412,11 +414,19 @@
       }
     },
     "@wdio/types": {
-      "version": "7.0.7",
-      "resolved": "https://registry.npmjs.org/@wdio/types/-/types-7.0.7.tgz",
-      "integrity": "sha512-4UiQevmw9is81RC8ZA6+HTsDAc/m4MGsWZ7UHBeLQGbpzLixexXbluZxF85xWsgFOanW20wVahfsU63gQ5byvQ==",
+      "version": "7.6.0",
+      "resolved": "https://registry.npmjs.org/@wdio/types/-/types-7.6.0.tgz",
+      "integrity": "sha512-BPPd7K6TpF4v1YaqUf+wDRwpys5asc7H7LDik4kHjLaGMwDfj+r0Goo3Z7xQn2fFdCuV99dkrI1N9vkgc2pDjA==",
       "requires": {
+        "@types/node": "^14.14.31",
         "got": "^11.8.1"
+      },
+      "dependencies": {
+        "@types/node": {
+          "version": "14.17.0",
+          "resolved": "https://registry.npmjs.org/@types/node/-/node-14.17.0.tgz",
+          "integrity": "sha512-w8VZUN/f7SSbvVReb9SWp6cJFevxb4/nkG65yLAya//98WgocKm5PLDAtSs5CtJJJM+kHmJjO/6mmYW4MHShZA=="
+        }
       }
     },
     "@wdio/utils": {
@@ -426,6 +436,16 @@
       "requires": {
         "@wdio/logger": "7.0.0",
         "@wdio/types": "7.0.7"
+      },
+      "dependencies": {
+        "@wdio/types": {
+          "version": "7.0.7",
+          "resolved": "https://registry.npmjs.org/@wdio/types/-/types-7.0.7.tgz",
+          "integrity": "sha512-4UiQevmw9is81RC8ZA6+HTsDAc/m4MGsWZ7UHBeLQGbpzLixexXbluZxF85xWsgFOanW20wVahfsU63gQ5byvQ==",
+          "requires": {
+            "got": "^11.8.1"
+          }
+        }
       }
     },
     "JSONStream": {
@@ -2702,6 +2722,16 @@
         "puppeteer-core": "^7.1.0",
         "ua-parser-js": "^0.7.21",
         "uuid": "^8.0.0"
+      },
+      "dependencies": {
+        "@wdio/types": {
+          "version": "7.0.7",
+          "resolved": "https://registry.npmjs.org/@wdio/types/-/types-7.0.7.tgz",
+          "integrity": "sha512-4UiQevmw9is81RC8ZA6+HTsDAc/m4MGsWZ7UHBeLQGbpzLixexXbluZxF85xWsgFOanW20wVahfsU63gQ5byvQ==",
+          "requires": {
+            "got": "^11.8.1"
+          }
+        }
       }
     },
     "devtools-protocol": {
@@ -8311,6 +8341,16 @@
         "@wdio/utils": "7.0.7",
         "got": "^11.0.2",
         "lodash.merge": "^4.6.1"
+      },
+      "dependencies": {
+        "@wdio/types": {
+          "version": "7.0.7",
+          "resolved": "https://registry.npmjs.org/@wdio/types/-/types-7.0.7.tgz",
+          "integrity": "sha512-4UiQevmw9is81RC8ZA6+HTsDAc/m4MGsWZ7UHBeLQGbpzLixexXbluZxF85xWsgFOanW20wVahfsU63gQ5byvQ==",
+          "requires": {
+            "got": "^11.8.1"
+          }
+        }
       }
     },
     "webdriverio": {
@@ -8345,6 +8385,14 @@
         "webdriver": "7.0.7"
       },
       "dependencies": {
+        "@wdio/types": {
+          "version": "7.0.7",
+          "resolved": "https://registry.npmjs.org/@wdio/types/-/types-7.0.7.tgz",
+          "integrity": "sha512-4UiQevmw9is81RC8ZA6+HTsDAc/m4MGsWZ7UHBeLQGbpzLixexXbluZxF85xWsgFOanW20wVahfsU63gQ5byvQ==",
+          "requires": {
+            "got": "^11.8.1"
+          }
+        },
         "fs-extra": {
           "version": "9.1.0",
           "resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-9.1.0.tgz",

--- a/package.json
+++ b/package.json
@@ -36,7 +36,7 @@
     "@gemini-testing/commander": "2.15.3",
     "@types/mocha": "^2.2.48",
     "@types/node": "^8.5.10",
-    "@types/webdriverio": "^4.13.3",
+    "@wdio/types": "^7.6.0",
     "@wdio/utils": "^7.0.7",
     "bluebird": "^3.5.1",
     "chalk": "^1.1.1",

--- a/typings/index.d.ts
+++ b/typings/index.d.ts
@@ -3,6 +3,7 @@
 /// <reference path='./mocha/index.d.ts' />
 /// <reference path='./gemini-core/index.d.ts' />
 /// <reference types='@gemini-testing/commander' />
+/// <reference types='@wdio/types' />
 
 class Hermione implements Hermione.Process {
     static create(configPath: string): Hermione;
@@ -211,7 +212,7 @@ declare namespace Hermione {
         (expectation: string, callback?: TestDefinitionCallback): Test;
     };
 
-    type TestDefinitionCallback = (this: { browser: WebdriverIO.Client<void> }, done: TestDone) => any;
+    type TestDefinitionCallback = (this: { browser: WebdriverIO.Browser }, done: TestDone) => any;
 
     interface TestDone {
         (error?: any): any;
@@ -309,7 +310,7 @@ declare namespace Hermione {
 
     export interface CommonConfig {
         configPath: string;
-        desiredCapabilities: WebdriverIO.DesiredCapabilities | null;
+        desiredCapabilities: WebDriver.DesiredCapabilities | null;
         gridUrl: string;
         baseUrl: string;
         sessionsPerBrowser: number;
@@ -327,7 +328,7 @@ declare namespace Hermione {
         saveHistoryOnError: boolean;
         screenshotOnReject: boolean;
         screenshotOnRejectTimeout: number | null;
-        prepareBrowser(browser: WebdriverIO.Client<void>): void | null;
+        prepareBrowser(browser: WebdriverIO.Browser): void | null;
         screenshotPath: string | null;
         screenshotsDir(test: Test): string;
         calibrate: boolean;
@@ -664,8 +665,8 @@ declare namespace Hermione {
         sessionId: string;
     };
 
-    export type AsyncSessionEventCallback = (browser: WebdriverIO.Client<void>, browserInfo: BrowserInfo) => Promise<void> | void;
-    export type SyncSessionEventCallback = (browser: WebdriverIO.Client<void>, browserInfo: { browserId: string, browserVersion: string}) => void;
+    export type AsyncSessionEventCallback = (browser: WebdriverIO.Browser, browserInfo: BrowserInfo) => Promise<void> | void;
+    export type SyncSessionEventCallback = (browser: WebdriverIO.Browser, browserInfo: { browserId: string, browserVersion: string}) => void;
     export type TestEventCallback = (test: Test) => void;
 };
 

--- a/typings/webdriverio/index.d.ts
+++ b/typings/webdriverio/index.d.ts
@@ -1,13 +1,13 @@
-/// <reference types='webdriverio' />
+/// <reference types='webdriverio/async' />
 
 declare namespace WebdriverIO {
-    export interface Client<T> {
-        getMeta(): Client<Hermione.BrowserMeta>;
+    interface Browser {
+        getMeta(): Browser<Hermione.BrowserMeta>;
         getMeta(key: string): Client<unknown>;
 
-        setMeta(key: string, value: unknown): Client<T>;
+        setMeta(key: string, value: unknown): void;
 
-        extendOptions(opts: { [name: string]: unknown }): Client<T>;
+        extendOptions(opts: { [name: string]: unknown }): void;
 
         /**
          * Takes a screenshot of the passed selector and compares the received screenshot with the reference.
@@ -42,6 +42,6 @@ declare namespace WebdriverIO {
          * @param opts additional options, currently available:
          * "ignoreElements", "tolerance", "antialiasingTolerance", "allowViewportOverflow", "captureElementFromTop", "compositeImage", "screenshotDelay"
          */
-        assertView(state: string, selectors: string | Array<string>, opts?: Hermione.AssertViewOpts): Client<T>;
+        assertView(state: string, selectors: string | Array<string>, opts?: Hermione.AssertViewOpts): void;
     }
 }


### PR DESCRIPTION
- remove deprecated typings from `@types/webdriverio`
- use new typings from webdriverio
- use new typings from `@wdio/types`

proofs that it works:
- one
![2021-05-24_13-11-15](https://user-images.githubusercontent.com/8089139/119344636-91182500-bca0-11eb-9948-2067a3f57c09.png)
- two
![2021-05-24_14-59-24](https://user-images.githubusercontent.com/8089139/119344742-aee58a00-bca0-11eb-9c3f-072c0f8464bd.png)
