### PR TITLE
fix: set correct screenshotMode for android browsers

### DIFF
--- a/README.md
+++ b/README.md
@@ -841,6 +841,8 @@ Image capture mode. There are 3 allowed values for this option:
   * `auto` (default). Mode will be obtained automatically;
   * `fullpage`. Hermione will deal with screenshot of full page;
   * `viewport`. Only viewport area will be used.
+  
+By default, `screenshotMode` on android browsers is set to `viewport` to work around [the chromium bug](https://bugs.chromium.org/p/chromedriver/issues/detail?id=2853).
 
 #### saveHistoryOnTestTimeout
 

--- a/lib/config/browser-options.js
+++ b/lib/config/browser-options.js
@@ -138,6 +138,23 @@ function buildBrowserOptions(defaultFactory, extra) {
                 if (!_.includes(['fullpage', 'viewport', 'auto'], value)) {
                     throw new Error('"screenshotMode" must be "fullpage", "viewport" or "auto"');
                 }
+            },
+            map: (value, config, currentNode) => {
+                if (value !== defaults.screenshotMode) {
+                    return value;
+                }
+
+                // Chrome mobile returns screenshots that are larger than visible viewport due to a bug:
+                // https://bugs.chromium.org/p/chromedriver/issues/detail?id=2853
+                // Due to this, screenshot is cropped incorrectly.
+                const capabilities = _.get(currentNode, 'desiredCapabilities');
+
+                const isAndroid = capabilities && Boolean(
+                    (capabilities.platformName && capabilities.platformName.match(/Android/i)) ||
+                    (capabilities.browserName && capabilities.browserName.match(/Android/i))
+                );
+
+                return isAndroid ? 'viewport' : value;
             }
         }),
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -3840,9 +3840,9 @@
       }
     },
     "gemini-configparser": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/gemini-configparser/-/gemini-configparser-1.0.0.tgz",
-      "integrity": "sha1-lKjZTqTqESh9nEChnHSSFo7toCA=",
+      "version": "1.0.1",
+      "resolved": "http://npm.yandex-team.ru/gemini-configparser/-/gemini-configparser-1.0.1.tgz?rbtorrent=6823ecc6726f8100653a3cda5c230a1ba623f13b",
+      "integrity": "sha512-T/hJVwuZDDBYebmCELNSeuPl/nFTz81JuEXpP9Wg5jYCL/AMYxweziRljiLHQwkm3BYVMWh07SwYrcljIBVStQ==",
       "requires": {
         "lodash": "^4.17.4"
       }

--- a/package.json
+++ b/package.json
@@ -42,7 +42,7 @@
     "chalk": "^1.1.1",
     "clear-require": "^1.0.1",
     "fs-extra": "^5.0.0",
-    "gemini-configparser": "^1.0.0",
+    "gemini-configparser": "^1.0.1",
     "gemini-core": "^6.1.3",
     "inherit": "^2.2.2",
     "json-stringify-safe": "^5.0.1",

--- a/test/lib/config/browser-options.js
+++ b/test/lib/config/browser-options.js
@@ -1159,6 +1159,45 @@ describe('config browser-options', () => {
             assert.equal(config.browsers.b1.screenshotMode, 'fullpage');
             assert.equal(config.browsers.b2.screenshotMode, 'viewport');
         });
+
+        describe('on android browser', () => {
+            it('should set mode to \'viewport\' by default', () => {
+                const readConfig = {
+                    browsers: {
+                        b1: mkBrowser_({
+                            desiredCapabilities: {
+                                platformName: 'android'
+                            }
+                        })
+                    }
+                };
+
+                Config.read.returns(readConfig);
+
+                const config = createConfig();
+
+                assert.equal(config.browsers.b1.screenshotMode, 'viewport');
+            });
+
+            it('should preserve manually set mode', () => {
+                const readConfig = {
+                    browsers: {
+                        b1: mkBrowser_({
+                            desiredCapabilities: {
+                                platformName: 'android'
+                            },
+                            screenshotMode: 'fullpage'
+                        })
+                    }
+                };
+
+                Config.read.returns(readConfig);
+
+                const config = createConfig();
+
+                assert.equal(config.browsers.b1.screenshotMode, 'fullpage');
+            });
+        });
     });
 
     describe('orientation', () => {


### PR DESCRIPTION
This PR sets `screenshotMode` to `'viewport'` for android browsers. These changes aim to get around the [chromium bug](https://bugs.chromium.org/p/chromedriver/issues/detail?id=2853) due to which screenshots turn out larger than the visible viewport and have blank space at the bottom.