### PR TITLE
fix(attach): pass "requestedCapabilities" in order to using CDP in CI

### DIFF
--- a/lib/browser/browser.js
+++ b/lib/browser/browser.js
@@ -77,7 +77,8 @@ module.exports = class Browser {
             ...detectedSessionEnvFlags,
             ...this._config.sessionEnvFlags,
             options: sessionOpts,
-            capabilities: {...sessionOpts.capabilities, ...sessionCaps}
+            capabilities: {...sessionOpts.capabilities, ...sessionCaps},
+            requestedCapabilities: sessionOpts.capabilities
         });
     }
 

--- a/test/lib/browser/existing-browser.js
+++ b/test/lib/browser/existing-browser.js
@@ -128,6 +128,16 @@ describe('ExistingBrowser', () => {
             });
         });
 
+        describe('in order to correctly connect to remote browser using CDP', () => {
+            it('should attach to browser with "requestedCapabilities" property', async () => {
+                const desiredCapabilities = {browserName: 'yabro', 'selenoid:options': {}};
+
+                await mkBrowser_({desiredCapabilities}).init();
+
+                assert.calledWithMatch(webdriverio.attach, {requestedCapabilities: desiredCapabilities});
+            });
+        });
+
         describe('commands-history', () => {
             beforeEach(() => {
                 sandbox.spy(history, 'initCommandHistory');


### PR DESCRIPTION
wdio при подключении к сессии с использованием CDP пытается понять нужно ли подключится к локальному браузеру или куда-то удаленно. Для того, чтобы это понять он смотрит на запрашиваемые пользователем капабилити. В случае если присутствует `selenoid:options`, то он понимает, что нужно подключится по урлу вида - `ws://${host}:4444/devtools/${browser.sessionId}`. Происходит это тут - https://github.com/webdriverio/webdriverio/blob/main/packages/webdriverio/src/commands/browser/getPuppeteer.ts#L71-L79.