### PR TITLE
fix: use 'any' instead of 'unknown' typing for ctx

### DIFF
--- a/typings/index.d.ts
+++ b/typings/index.d.ts
@@ -338,7 +338,7 @@ declare namespace Hermione {
     };
 
     export interface GlobalHelper {
-        ctx: { [name: string]: unknown };
+        ctx: { [name: string]: any };
         skip: SkipBuilder;
         only: OnlyBuilder;
         browser: (browserName: string) => BrowserConfigurator


### PR DESCRIPTION
Проблема:
При использовании `unknown` TS будет ругаться если в `ctx` положить функцию-хелпер

Пример:
`ctx: {
  login: loginFunction
}`

В качестве решения - использовать `any`