### PR TITLE
fix: correct logic for running it.only/describe.only

### DIFF
--- a/lib/test-reader/mocha-test-parser.js
+++ b/lib/test-reader/mocha-test-parser.js
@@ -170,6 +170,9 @@ module.exports = class MochaTestParser extends EventEmitter {
         });
 
         this._mocha.loadFiles();
+        if (this._mocha.suite.hasOnly()) {
+            this._mocha.suite.filterOnly();
+        }
         this._mocha.files = [];
 
         this._validateUniqTitles();

--- a/test/lib/_mocha/suite.js
+++ b/test/lib/_mocha/suite.js
@@ -146,6 +146,14 @@ module.exports = class Suite extends EventEmitter {
         this.suites.forEach((suite) => suite.eachTest(fn));
     }
 
+    filterOnly() {
+        return this;
+    }
+
+    hasOnly() {
+        return true;
+    }
+
     run(runner) {
         return Promise.resolve()
             .then(this._execRunnables(this.beforeAllHooks))

--- a/test/lib/test-reader/mocha-test-parser.js
+++ b/test/lib/test-reader/mocha-test-parser.js
@@ -144,6 +144,16 @@ describe('test-reader/mocha-test-parser', () => {
             assert.callOrder(MochaStub.lastInstance.addFile, MochaStub.lastInstance.loadFiles);
         });
 
+        it('should filter suites/tests with `only`', () => {
+            sandbox.stub(MochaStub.Suite.prototype, 'filterOnly');
+            const mochaTestParser = mkMochaTestParser_();
+
+            mochaTestParser.loadFiles(['path/to/file']);
+
+            assert.calledOnce(MochaStub.Suite.prototype.filterOnly);
+            assert.callOrder(MochaStub.lastInstance.loadFiles, MochaStub.Suite.prototype.filterOnly);
+        });
+
         it('should flush files after load', () => {
             const mochaTestParser = mkMochaTestParser_();
 


### PR DESCRIPTION
После переезда на новую моку перестала работать фильтрация сьютов с использованеием `.only`. Перестала она работать из-за того, что в моке эта логика уехала в [раннер](https://github.com/gemini-testing/mocha/blob/master/lib/runner.js#L1066), а этот раннер гермиона не использует. 
Поэтому после чтения тестов нужно явно вызвать у корневого сьюта метод, который фильтрует тесты.