### PR TITLE
Feat: pass browser into test as an argument

### DIFF
--- a/lib/worker/runner/test-runner/execution-thread.js
+++ b/lib/worker/runner/test-runner/execution-thread.js
@@ -34,7 +34,7 @@ module.exports = class ExecutionThread {
     }
 
     _call(runnable) {
-        let fnPromise = Promise.method(runnable.fn).apply(this._ctx);
+        let fnPromise = Promise.method(runnable.fn).call(this._ctx, this._ctx);
 
         if (runnable.timeout()) {
             const msg = `${runnable.type} '${runnable.fullTitle()}' timed out after ${runnable.timeout()} ms`;


### PR DESCRIPTION
```js
it('some test', async function() {
    await this.browser.url('foo/bar');
});
```
=>
```js
it('some test', async ({ browser }) => {
    await browser.url('foo/bar');
});
```