### PR TITLE
fix: do not passthrough parser events via TestParserApi

### DIFF
--- a/README.md
+++ b/README.md
@@ -119,7 +119,6 @@ Hermione is a utility for integration testing of web pages using [WebdriverIO v7
   - [Test Collection](#test-collection)
   - [Test Parser API](#test-parser-api)
     - [setController(name, methods)](#setcontrollername-methods)
-    - [events](#events)
 
 <!-- END doctoc generated TOC please keep comment here to allow auto update -->
 
@@ -1610,25 +1609,3 @@ describe('foo', () => {
 ```
 
 **Note**: controller will be removed as soon as current file will be parsed
-
-#### events
-
-Parser events list for subscription.
-
-**Available events which are triggered in the TestParserAPI**
-
-Event             | Description
------------------ | -------------
-`TEST`            | Will be triggered on test parsing. The handler accepts test instance.
-`SUITE`           | Will be triggered on suite parsing. The handler accepts suite instance.
-`HOOK`            | Will be triggered on hook parsing. The handler accepts hook instance.
-
-Example:
-```js
-// in plugin
-hermione.on(hermione.events.BEFORE_FILE_READ, ({testParser}) => {
-    testParser.on(testParser.events.TEST, (test) => {
-        console.log('my awesome test:', test);
-    });
-});
-```

--- a/lib/test-reader/test-parser-api.js
+++ b/lib/test-reader/test-parser-api.js
@@ -1,32 +1,18 @@
 'use strict';
 
-const {EventEmitter} = require('events');
 const _ = require('lodash');
 const ParserEvents = require('./parser-events');
 const RunnerEvents = require('../constants/runner-events');
-const eventsUtils = require('gemini-core').events.utils;
 
-module.exports = class TestParserAPI extends EventEmitter {
+module.exports = class TestParserAPI {
     static create(...args) {
         return new this(...args);
     }
 
     constructor(parser, ctx) {
-        super();
-
         this._ctx = ctx;
         this._parser = parser;
         this._delayedCalls = [];
-
-        eventsUtils.passthroughEvent(this._parser, this, [
-            ParserEvents.TEST,
-            ParserEvents.SUITE,
-            ParserEvents.HOOK
-        ]);
-    }
-
-    get events() {
-        return ParserEvents;
     }
 
     setController(name, methods) {

--- a/test/lib/test-reader/test-parser-api.js
+++ b/test/lib/test-reader/test-parser-api.js
@@ -5,18 +5,11 @@ const TestParserAPI = require('lib/test-reader/test-parser-api');
 const ParserEvents = require('lib/test-reader/parser-events');
 const RunnerEvents = require('lib/constants/runner-events');
 const {makeSuite, makeTest} = require('../../utils');
-const eventsUtils = require('gemini-core').events.utils;
 
 describe('test-reader/test-parser-api', () => {
-    const sandbox = sinon.sandbox.create();
-
     const mkTestParser_ = () => {
         return new EventEmitter();
     };
-
-    afterEach(() => {
-        sandbox.restore();
-    });
 
     describe('setController', () => {
         it('should set appropriate controller to context', () => {
@@ -144,25 +137,6 @@ describe('test-reader/test-parser-api', () => {
 
             assert.calledOnce(doStuff);
             assert.calledOn(doStuff, test);
-        });
-
-        it('should pass through all parser events', () => {
-            const hermione = {};
-            const testParser = mkTestParser_();
-            const doStuff = sandbox.stub(eventsUtils, 'passthroughEvent');
-
-            const testParserAPI = TestParserAPI.create(testParser, hermione);
-
-            assert.calledOnceWith(
-                doStuff,
-                testParser,
-                testParserAPI,
-                [
-                    ParserEvents.TEST,
-                    ParserEvents.SUITE,
-                    ParserEvents.HOOK
-                ]
-            );
         });
     });
 });


### PR DESCRIPTION
Reverting https://github.com/gemini-testing/hermione/pull/495

Внесенная там функциональность никогда не работала корректно: на нижнем уровне парсер, от которого, пробрасываются события, создается один раз перед чтением **всех файлов** для конкретного браузера, и соответственно через [testParserApi](https://github.com/gemini-testing/hermione#test-parser-api) будут лететь события о всех тестах/хуках из всех файлов. При этом сам объект летит на событие `BEFORE_FILE_READ`, т.е. стоит подписаться в обработчике этого события, и для каждого файла будут лететь события о тестах/хуках из всех файлов.

И судя по тому, что за 2 года не было ни одного обращения про этот баг, то никто этим и не пользуется.

Предлагаю откатить функциональность здесь и ее использование в https://github.com/gemini-testing/hermione-test-filter. А если все же она кому-то понадобится, то реализовать добавлением публичного доступа к хукам у сьюта (он и так есть, на самом деле, только "приватный": для примера можно [посмотреть](https://github.com/gemini-testing/hermione/blob/v4.9.1/lib/worker/runner/test-runner/hook-runner.js#L46) как с хуками работает HookRunner

PR с откатом в test-filter: https://github.com/gemini-testing/hermione-test-filter/pull/11