### PR TITLE
fix: 'this' pointer in custom commands

### DIFF
--- a/lib/browser/history/index.js
+++ b/lib/browser/history/index.js
@@ -32,11 +32,13 @@ const overwriteAddCommand = (session, callstack) => session
             return origCommand(name, wrapper, elementScope);
         }
 
-        const decoratedWrapper = (...args) => runWithHooks({
-            before: () => callstack.enter(mkNodeData({name, args, elementScope, overwrite: false})),
-            fn: () => wrapper.apply(session, args),
-            after: () => callstack.leave()
-        });
+        function decoratedWrapper(...args) {
+            return runWithHooks({
+                before: () => callstack.enter(mkNodeData({name, args, elementScope, overwrite: false})),
+                fn: () => wrapper.apply(this, args),
+                after: () => callstack.leave()
+            });
+        }
 
         return origCommand(name, decoratedWrapper, elementScope);
     });
@@ -47,11 +49,13 @@ const overwriteOverwriteCommand = (session, callstack) => session
             return origCommand(name, wrapper, elementScope);
         }
 
-        const decoratedWrapper = (origFn, ...args) => runWithHooks({
-            before: () => callstack.enter(mkNodeData({name, args, elementScope, overwrite: true})),
-            fn: () => wrapper.apply(session, [origFn, ...args]),
-            after: () => callstack.leave()
-        });
+        function decoratedWrapper(origFn, ...args) {
+            return runWithHooks({
+                before: () => callstack.enter(mkNodeData({name, args, elementScope, overwrite: true})),
+                fn: () => wrapper.apply(this, [origFn, ...args]),
+                after: () => callstack.leave()
+            });
+        }
 
         return origCommand(name, decoratedWrapper, elementScope);
     });

--- a/test/lib/browser/history/index.js
+++ b/test/lib/browser/history/index.js
@@ -70,9 +70,38 @@ describe('commands-history', () => {
                 return this;
             });
 
-            const resultContest = await session.foo();
+            const resultContext = await session.foo();
 
-            assert.equal(resultContest, session);
+            assert.equal(resultContext, session);
+        });
+
+        it('should save element context while wrapping for "addCommand" with elemScope: true', async () => {
+            const session = mkSessionStub_();
+
+            initCommandHistory(session);
+            session.addCommand('foo', function() {
+                return this;
+            }, true);
+
+            const elem = await session.$('.selector');
+            const resultContext = elem.foo();
+
+            assert.equal(resultContext, elem);
+        });
+
+        it('should save element context while wrapping for "overwriteCommand" with elemScope: true', async () => {
+            const session = mkSessionStub_();
+
+            initCommandHistory(session);
+            session.addCommand('foo', ()=>{}, true);
+            session.overwriteCommand('foo', function() {
+                return this;
+            }, true);
+
+            const elem = await session.$('.selector');
+            const resultContext = elem.foo();
+
+            assert.equal(resultContext, elem);
         });
 
         it('should wrap browser commands', async () => {

--- a/test/lib/browser/utils.js
+++ b/test/lib/browser/utils.js
@@ -79,9 +79,11 @@ exports.mkSessionStub_ = () => {
     session.setTimeouts = sinon.stub().named('setTimeouts').resolves();
     session.$ = sinon.stub().named('$').resolves(element);
 
-    session.addCommand = sinon.stub().callsFake((name, command) => {
-        session[name] = command;
-        sinon.spy(session, name);
+    session.addCommand = sinon.stub().callsFake((name, command, isElement) => {
+        const target = isElement ? element : session;
+
+        target[name] = command.bind(target);
+        sinon.spy(target, name);
     });
 
     session.overwriteCommand = sinon.stub().callsFake((name, command, isElement) => {


### PR DESCRIPTION
when `saveHistory` enabled, `this` in commands, added via addCommand, pointed to browser even with `elementScope=true` flag

```
it('...', async ({browser}) => {
  browser.addCommand('foobar', async function() {
    console.log('this:', this); // browser instance, must be an element instance
  }, true);
});
  ```