### PR TITLE
feat: load test files asynchronously

### DIFF
--- a/lib/test-reader/index.js
+++ b/lib/test-reader/index.js
@@ -2,6 +2,7 @@
 
 const _ = require('lodash');
 const {EventEmitter} = require('events');
+const Promise = require('bluebird');
 const {passthroughEvent} = require('../core/events/utils');
 const SetsBuilder = require('../core/sets-builder');
 const TestParser = require('./mocha-test-parser');
@@ -36,11 +37,10 @@ module.exports = class TestReader extends EventEmitter {
 
         const filesByBro = setCollection.groupByBrowser();
 
-        const testsByBro = _(filesByBro)
-            .mapValues((files, browserId) => ({parser: this._makeParser(browserId, grep), files}))
-            .mapValues(({parser, files}) => parser.loadFiles(files))
-            .mapValues((parser) => parser.parse())
-            .value();
+        const parsersWithFiles = Object.entries(filesByBro).map(([browserId, files]) => [this._makeParser(browserId, grep), files]);
+        const loadedParsers = await Promise.mapSeries(parsersWithFiles, async ([parser, files]) => await parser.loadFiles(files));
+        const testGroups = loadedParsers.map((parser) => parser.parse());
+        const testsByBro = _.zipObject(Object.keys(filesByBro), testGroups);
 
         validateTests(testsByBro, options);
 

--- a/lib/test-reader/mocha-test-parser.js
+++ b/lib/test-reader/mocha-test-parser.js
@@ -160,7 +160,7 @@ module.exports = class MochaTestParser extends EventEmitter {
         return this;
     }
 
-    loadFiles(files) {
+    async loadFiles(files) {
         global.hermione.ctx = _.clone(this._browserConfig.system.ctx);
 
         this._injectSkip(global.hermione);
@@ -171,7 +171,7 @@ module.exports = class MochaTestParser extends EventEmitter {
             this._mocha.addFile(filename);
         });
 
-        this._mocha.loadFiles();
+        await this._mocha.loadFilesAsync();
         if (this._mocha.suite.hasOnly()) {
             this._mocha.suite.filterOnly();
         }

--- a/lib/worker/runner/caching-test-parser.js
+++ b/lib/worker/runner/caching-test-parser.js
@@ -20,13 +20,13 @@ module.exports = class CachingTestParser extends EventEmitter {
         TestParser.prepare();
     }
 
-    parse({file, browserId}) {
+    async parse({file, browserId}) {
         const cached = this._getFromCache({file, browserId});
         if (cached) {
             return cached;
         }
 
-        const tests = this._parse({file, browserId});
+        const tests = await this._parse({file, browserId});
         this._putToCache(tests, {file, browserId});
         this.emit(RunnerEvents.AFTER_TESTS_READ, TestCollection.create({[browserId]: tests}, this._config));
 
@@ -42,7 +42,7 @@ module.exports = class CachingTestParser extends EventEmitter {
         this._cache[browserId][file] = tests;
     }
 
-    _parse({file, browserId}) {
+    async _parse({file, browserId}) {
         const parser = TestParser.create(browserId, this._config);
 
         passthroughEvent(parser, this, [
@@ -50,9 +50,10 @@ module.exports = class CachingTestParser extends EventEmitter {
             RunnerEvents.AFTER_FILE_READ
         ]);
 
-        return parser
-            .applyConfigController()
-            .loadFiles(file)
-            .parse();
+        parser.applyConfigController();
+
+        await parser.loadFiles(file);
+
+        return parser.parse();
     }
 };

--- a/lib/worker/runner/index.js
+++ b/lib/worker/runner/index.js
@@ -27,8 +27,8 @@ module.exports = class Runner extends AsyncEmitter {
         ]);
     }
 
-    runTest(fullTitle, {browserId, browserVersion, file, sessionId, sessionCaps, sessionOpts}) {
-        const tests = this._testParser.parse({file, browserId});
+    async runTest(fullTitle, {browserId, browserVersion, file, sessionId, sessionCaps, sessionOpts}) {
+        const tests = await this._testParser.parse({file, browserId});
         const test = tests.find((t) => t.fullTitle() === fullTitle);
         const browserAgent = BrowserAgent.create(browserId, browserVersion, this._browserPool);
         const runner = TestRunner.create(test, this._config.forBrowser(browserId), browserAgent);

--- a/lib/worker/runner/test-runner/index.js
+++ b/lib/worker/runner/test-runner/index.js
@@ -84,9 +84,9 @@ module.exports = class TestRunner {
 
         if (error) {
             throw Object.assign(error, results);
-        } else {
-            return results;
         }
+
+        return results;
     }
 
     async _resetCursorPosition({publicAPI: session}) {

--- a/test/lib/_mocha/index.js
+++ b/test/lib/_mocha/index.js
@@ -14,7 +14,7 @@ class Mocha extends EventEmitter {
 
         this.files = [];
         sinon.spy(this, 'addFile');
-        this.loadFiles = sinon.stub();
+        this.loadFilesAsync = sinon.stub().resolves();
         this.fullTrace = sinon.stub();
         this.timeout = sinon.stub();
         this.reporter = sinon.stub().callsFake((fn) => this._reporter = fn);

--- a/test/lib/test-reader/mocha-test-parser.js
+++ b/test/lib/test-reader/mocha-test-parser.js
@@ -105,132 +105,144 @@ describe('test-reader/mocha-test-parser', () => {
     });
 
     describe('loadFiles', () => {
-        it('should be chainable', () => {
+        it('should be chainable', async () => {
             const mochaTestParser = mkMochaTestParser_();
 
-            assert.deepEqual(mochaTestParser.loadFiles(['path/to/file']), mochaTestParser);
+            assert.deepEqual(await mochaTestParser.loadFiles(['path/to/file']), mochaTestParser);
         });
 
-        it('should load files', () => {
+        it('should load files', async () => {
             const mochaTestParser = mkMochaTestParser_();
 
-            mochaTestParser.loadFiles(['path/to/file']);
+            await mochaTestParser.loadFiles(['path/to/file']);
 
             assert.calledOnceWith(MochaStub.lastInstance.addFile, 'path/to/file');
         });
 
-        it('should load a single file', () => {
+        it('should load a single file', async () => {
             const mochaTestParser = mkMochaTestParser_();
 
-            mochaTestParser.loadFiles('path/to/file');
+            await mochaTestParser.loadFiles('path/to/file');
 
             assert.calledOnceWith(MochaStub.lastInstance.addFile, 'path/to/file');
         });
 
-        it('should clear require cache for file before adding', () => {
+        it('should clear require cache for file before adding', async () => {
             const mochaTestParser = mkMochaTestParser_();
 
-            mochaTestParser.loadFiles(['path/to/file']);
+            await mochaTestParser.loadFiles(['path/to/file']);
 
             assert.calledOnceWith(clearRequire, path.resolve('path/to/file'));
             assert.callOrder(clearRequire, MochaStub.lastInstance.addFile);
         });
 
-        it('should load file after add', () => {
+        it('should load file after add', async () => {
             const mochaTestParser = mkMochaTestParser_();
 
-            mochaTestParser.loadFiles(['path/to/file']);
+            await mochaTestParser.loadFiles(['path/to/file']);
 
-            assert.calledOnce(MochaStub.lastInstance.loadFiles);
-            assert.callOrder(MochaStub.lastInstance.addFile, MochaStub.lastInstance.loadFiles);
+            assert.calledOnce(MochaStub.lastInstance.loadFilesAsync);
+            assert.callOrder(MochaStub.lastInstance.addFile, MochaStub.lastInstance.loadFilesAsync);
         });
 
-        it('should filter suites/tests with `only`', () => {
+        it('should filter suites/tests with `only`', async () => {
             sandbox.stub(MochaStub.Suite.prototype, 'filterOnly');
             const mochaTestParser = mkMochaTestParser_();
 
-            mochaTestParser.loadFiles(['path/to/file']);
+            await mochaTestParser.loadFiles(['path/to/file']);
 
             assert.calledOnce(MochaStub.Suite.prototype.filterOnly);
-            assert.callOrder(MochaStub.lastInstance.loadFiles, MochaStub.Suite.prototype.filterOnly);
+            assert.callOrder(MochaStub.lastInstance.loadFilesAsync, MochaStub.Suite.prototype.filterOnly);
         });
 
-        it('should flush files after load', () => {
+        it('should flush files after load', async () => {
             const mochaTestParser = mkMochaTestParser_();
 
-            mochaTestParser.loadFiles(['path/to/file']);
+            await mochaTestParser.loadFiles(['path/to/file']);
 
             assert.deepEqual(MochaStub.lastInstance.files, []);
         });
 
-        it('should throw in case of duplicate test titles in different files', () => {
+        it('should throw in case of duplicate test titles in different files', async () => {
             const mochaTestParser = mkMochaTestParser_();
 
-            MochaStub.lastInstance.loadFiles.callsFake(() => {
+            MochaStub.lastInstance.loadFilesAsync.callsFake(async () => {
                 MochaStub.lastInstance.updateSuiteTree((suite) => {
                     return suite
                         .addTest({title: 'some test', file: 'first file'})
                         .addTest({title: 'some test', file: 'second file'});
                 });
+
+                return Promise.resolve();
             });
 
-            assert.throws(() => mochaTestParser.loadFiles([]),
-                'Tests with the same title \'some test\' in files \'first file\' and \'second file\' can\'t be used');
+            await assert.isRejected(
+                mochaTestParser.loadFiles([]),
+                'Tests with the same title \'some test\' in files \'first file\' and \'second file\' can\'t be used'
+            );
         });
 
-        it('should throw in case of duplicate test titles in the same file', () => {
+        it('should throw in case of duplicate test titles in the same file', async () => {
             const mochaTestParser = mkMochaTestParser_();
 
-            MochaStub.lastInstance.loadFiles.callsFake(() => {
+            MochaStub.lastInstance.loadFilesAsync.callsFake(async () => {
                 MochaStub.lastInstance.updateSuiteTree((suite) => {
                     return suite
                         .addTest({title: 'some test', file: 'some file'})
                         .addTest({title: 'some test', file: 'some file'});
                 });
+
+                return Promise.resolve();
             });
 
-            assert.throws(() => mochaTestParser.loadFiles([]),
-                'Tests with the same title \'some test\' in file \'some file\' can\'t be used');
+            await assert.isRejected(
+                mochaTestParser.loadFiles([]),
+                'Tests with the same title \'some test\' in file \'some file\' can\'t be used'
+            );
         });
 
-        it('should emit TEST event on test creation', () => {
+        it('should emit TEST event on test creation', async () => {
             const onTest = sinon.spy().named('onTest');
             const mochaTestParser = mkMochaTestParser_()
                 .on(ParserEvents.TEST, onTest);
 
             const test = MochaStub.Test.create();
 
-            MochaStub.lastInstance.loadFiles.callsFake(() => {
+            MochaStub.lastInstance.loadFilesAsync.callsFake(async () => {
                 MochaStub.lastInstance.updateSuiteTree((suite) => suite.addTest(test));
+
+                return Promise.resolve();
             });
 
-            mochaTestParser.loadFiles([]);
+            await mochaTestParser.loadFiles([]);
 
             assert.calledOnceWith(onTest, test);
         });
 
-        it('should emit SUITE event on suite creation', () => {
+        it('should emit SUITE event on suite creation', async () => {
             const onSuite = sinon.spy().named('onSuite');
             const mochaTestParser = mkMochaTestParser_()
                 .on(ParserEvents.SUITE, onSuite);
 
             const nestedSuite = MochaStub.Suite.create();
 
-            MochaStub.lastInstance.loadFiles.callsFake(() => {
+            MochaStub.lastInstance.loadFilesAsync.callsFake(async () => {
                 MochaStub.lastInstance.updateSuiteTree((suite) => suite.addSuite(nestedSuite));
+
+                return Promise.resolve();
             });
 
-            mochaTestParser.loadFiles([]);
+            await mochaTestParser.loadFiles([]);
 
             assert.calledOnceWith(onSuite, nestedSuite);
         });
 
-        it('hermione.ctx should return passed ctx', () => {
+        it('hermione.ctx should return passed ctx', async () => {
             const system = {ctx: {some: 'ctx'}};
             const config = makeConfigStub({browsers: ['bro'], system});
             const mochaTestParser = mkMochaTestParser_({browserId: 'bro', config});
 
-            mochaTestParser.loadFiles([]);
+            await mochaTestParser.loadFiles([]);
 
             assert.deepEqual(global.hermione.ctx, {some: 'ctx'});
         });
@@ -238,11 +250,11 @@ describe('test-reader/mocha-test-parser', () => {
         describe('inject skip', () => {
             let mochaTestParser;
 
-            beforeEach(() => {
+            beforeEach(async () => {
                 sandbox.stub(Skip.prototype, 'handleEntity');
 
                 mochaTestParser = mkMochaTestParser_();
-                mochaTestParser.loadFiles([]);
+                await mochaTestParser.loadFiles([]);
             });
 
             it('hermione.skip should return SkipBuilder instance', () => {
@@ -283,14 +295,14 @@ describe('test-reader/mocha-test-parser', () => {
             const config = makeConfigStub({browsers: [browserId]});
             const configurator = new BrowserConfigurator(browserId, []);
 
-            beforeEach(() => {
+            beforeEach(async () => {
                 BrowserConfiguratorStubConstructor.returns(configurator);
                 sandbox.stub(configurator, 'exposeAPI').returns(api);
                 sandbox.stub(configurator, 'handleTest');
                 sandbox.stub(configurator, 'handleSuite');
 
                 mochaTestParser = mkMochaTestParser_({config, browserId});
-                mochaTestParser.loadFiles([]);
+                await mochaTestParser.loadFiles([]);
             });
 
             it('should pass the config and the "browserId" param into the constructor', () => {

--- a/test/lib/worker/runner/index.js
+++ b/test/lib/worker/runner/index.js
@@ -20,7 +20,7 @@ describe('worker/runner', () => {
         sandbox.stub(BrowserPool, 'create').returns({browser: 'pool'});
 
         sandbox.stub(CachingTestParser, 'create').returns(Object.create(CachingTestParser.prototype));
-        sandbox.stub(CachingTestParser.prototype, 'parse').returns([]);
+        sandbox.stub(CachingTestParser.prototype, 'parse').resolves([]);
 
         sandbox.stub(TestRunner, 'create').returns(Object.create(TestRunner.prototype));
         sandbox.stub(TestRunner.prototype, 'run').resolves();
@@ -66,70 +66,70 @@ describe('worker/runner', () => {
     });
 
     describe('runTest', () => {
-        it('should parse passed file in passed browser', () => {
+        it('should parse passed file in passed browser', async () => {
             const runner = mkRunner_();
 
-            runner.runTest(null, {file: 'some/file.js', browserId: 'bro'});
+            await runner.runTest(null, {file: 'some/file.js', browserId: 'bro'});
 
             assert.calledOnceWith(CachingTestParser.prototype.parse, {file: 'some/file.js', browserId: 'bro'});
         });
 
-        it('should create test runner for parsed test', () => {
+        it('should create test runner for parsed test', async () => {
             const runner = mkRunner_();
 
             const test = makeTest({fullTitle: () => 'some test'});
-            CachingTestParser.prototype.parse.returns([test]);
+            CachingTestParser.prototype.parse.resolves([test]);
 
-            runner.runTest('some test', {});
+            await runner.runTest('some test', {});
 
             assert.calledOnceWith(TestRunner.create, test);
         });
 
-        it('should pass browser config to test runner', () => {
+        it('should pass browser config to test runner', async () => {
             const config = makeConfigStub({browsers: ['bro']});
             const runner = mkRunner_({config});
 
             const test = makeTest({fullTitle: () => 'some test'});
-            CachingTestParser.prototype.parse.returns([test]);
+            CachingTestParser.prototype.parse.resolves([test]);
 
-            runner.runTest('some test', {browserId: 'bro'});
+            await runner.runTest('some test', {browserId: 'bro'});
 
             assert.calledOnceWith(TestRunner.create, test, config.forBrowser('bro'));
         });
 
-        it('should create browser agent for test runner', () => {
+        it('should create browser agent for test runner', async () => {
             const runner = mkRunner_();
 
             const test = makeTest({fullTitle: () => 'some test'});
-            CachingTestParser.prototype.parse.returns([test]);
+            CachingTestParser.prototype.parse.resolves([test]);
 
             const browserAgent = Object.create(BrowserAgent.prototype);
             BrowserAgent.create.withArgs('bro').returns(browserAgent);
 
-            runner.runTest('some test', {browserId: 'bro'});
+            await runner.runTest('some test', {browserId: 'bro'});
 
             assert.calledOnceWith(TestRunner.create, test, sinon.match.any, browserAgent);
         });
 
-        it('should create test runner only for passed test', () => {
+        it('should create test runner only for passed test', async () => {
             const runner = mkRunner_();
 
             const test1 = makeTest({fullTitle: () => 'some test'});
             const test2 = makeTest({fullTitle: () => 'other test'});
-            CachingTestParser.prototype.parse.returns([test1, test2]);
+            CachingTestParser.prototype.parse.resolves([test1, test2]);
 
-            runner.runTest('other test', {});
+            await runner.runTest('other test', {});
 
             assert.calledOnceWith(TestRunner.create, test2);
         });
 
-        it('should run test in passed session', () => {
+        it('should run test in passed session', async () => {
             const runner = mkRunner_();
 
             const test = makeTest({fullTitle: () => 'some test'});
-            CachingTestParser.prototype.parse.returns([test]);
+            CachingTestParser.prototype.parse.resolves([test]);
 
-            runner.runTest('some test', {sessionId: '100500', sessionCaps: 'some-caps', sessionOpts: 'some-opts'});
+            await runner.runTest('some test', {sessionId: '100500', sessionCaps: 'some-caps', sessionOpts: 'some-opts'});
 
             assert.calledOnceWith(
                 TestRunner.prototype.run,


### PR DESCRIPTION
2 ключевых момента:
- для одного браузера тестовые файлы грузятся асинхронно
- для разных браузеров пачки тестов грузятся последовательно. В этом отличие от https://github.com/gemini-testing/hermione/pull/612, и без этого парсинг для нескольких браузеров корректно не пройдет - внутри файлов с тестами активно используется global (и нами и mocha), будут конфликты

**Важно**: ESM-модули пока корректно работать не будут, т.к. там другая система кэширования. Это буду чинить отдельно