### PR TITLE
chore: remove redundant code for saving useless image

### DIFF
--- a/lib/worker/runner/test-runner/one-time-screenshooter.js
+++ b/lib/worker/runner/test-runner/one-time-screenshooter.js
@@ -1,12 +1,9 @@
 'use strict';
 
 const Promise = require('bluebird');
-const fs = require('fs');
 
 const Image = require('../../../image');
 const ScreenShooter = require('../../../core/screen-shooter');
-const temp = require('../../../temp');
-const RuntimeConfig = require('../../../config/runtime-config');
 const logger = require('../../../utils/logger');
 
 module.exports = class OneTimeScreenshooter {
@@ -88,7 +85,10 @@ module.exports = class OneTimeScreenshooter {
             allowViewportOverflow: true
         });
 
-        return this._saveImage(image);
+        const {data, size} = await image.toPngBuffer();
+        const base64 = data.toString('base64');
+
+        return {base64, size};
     }
 
     async _getPageSize() {
@@ -96,19 +96,6 @@ module.exports = class OneTimeScreenshooter {
             height: document.documentElement.scrollHeight,
             width: document.documentElement.scrollWidth
         }`);
-    }
-
-    async _saveImage(image) {
-        const {tempOpts} = RuntimeConfig.getInstance();
-        temp.attach(tempOpts);
-
-        const path = temp.path(Object.assign({}, tempOpts, {suffix: '.png'}));
-        const {data, size} = await image.toPngBuffer();
-        const base64 = data.toString('base64');
-
-        await fs.promises.writeFile(path, data);
-
-        return {base64, size};
     }
 
     async _makeViewportScreenshot() {

--- a/test/lib/worker/runner/test-runner/one-time-screenshooter.js
+++ b/test/lib/worker/runner/test-runner/one-time-screenshooter.js
@@ -2,12 +2,9 @@
 
 const _ = require('lodash');
 const Promise = require('bluebird');
-const fs = require('fs');
 const Image = require('lib/image');
 const ScreenShooter = require('lib/core/screen-shooter');
-const temp = require('lib/temp');
 const OneTimeScreenshooter = require('lib/worker/runner/test-runner/one-time-screenshooter');
-const RuntimeConfig = require('lib/config/runtime-config');
 const logger = require('lib/utils/logger');
 const {mkSessionStub_} = require('../../../browser/utils');
 
@@ -51,11 +48,7 @@ describe('worker/runner/test-runner/one-time-screenshooter', () => {
     beforeEach(() => {
         sandbox.stub(ScreenShooter.prototype, 'capture').resolves(stubImage_());
         sandbox.stub(Image, 'fromBase64').returns(stubImage_());
-        sandbox.stub(temp, 'attach').named('attach').returns();
-        sandbox.stub(temp, 'path').named('path').returns();
-        sandbox.stub(RuntimeConfig, 'getInstance').returns({tempOpts: {}});
         sandbox.stub(logger, 'warn');
-        sandbox.stub(fs.promises, 'writeFile').resolves();
     });
 
     afterEach(() => sandbox.restore());
@@ -109,16 +102,12 @@ describe('worker/runner/test-runner/one-time-screenshooter', () => {
                     allowViewportOverflow: true
                 })
                 .resolves(imgStub);
-            RuntimeConfig.getInstance.returns({tempOpts: {some: 'opts'}});
-            temp.path
-                .withArgs({some: 'opts', suffix: '.png'})
-                .returns('some-path');
+
             const config = {takeScreenshotOnFailsMode: 'fullpage'};
             const screenshooter = mkScreenshooter_({browser, config});
 
             await screenshooter[method](...getArgs());
 
-            assert.calledOnceWith(fs.promises.writeFile, 'some-path', Buffer.from('buffer'));
             assert.deepEqual(screenshooter.getScreenshot(), {
                 base64: Buffer.from('buffer').toString('base64'),
                 size: {width: 100, height: 500}


### PR DESCRIPTION
Осталось после https://github.com/gemini-testing/hermione/pull/663

`png-img` просто не умел сохранять в `base64`, поэтому мы сохраняли во временный файл, а потом просто читали этот файл через `fs` и конвертировали в `base64`.
После перехода на `sharp` этот костыль стал бесполезен