### PR TITLE
feat: drop node versions less than 14

### DIFF
--- a/.github/workflows/node.js.yml
+++ b/.github/workflows/node.js.yml
@@ -16,7 +16,7 @@ jobs:
 
     strategy:
       matrix:
-        node-version: [12.x, 14.x, 16.x, 18.x]
+        node-version: [14.x, 16.x, 18.x]
         # See supported Node.js release schedule at https://nodejs.org/en/about/releases/
 
     steps:

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,0 @@
-language: node_js
-node_js:
-- '12'
-script:
-- npm test --coverage
-after_success: cat ${TRAVIS_BUILD_DIR}/coverage/lcov.info | coveralls

--- a/package.json
+++ b/package.json
@@ -22,7 +22,7 @@
     "url": "git://github.com/gemini-testing/hermione.git"
   },
   "engines": {
-    "node": ">= 12.0.0"
+    "node": ">= 14.0.0"
   },
   "keywords": [
     "hermione",


### PR DESCRIPTION
BREAKING CHANGE: node versions less than 14.0.0 are no longer supported