### PR TITLE
fix: use test.clone instead of Object.create(test) to avoid test modification

### DIFF
--- a/README.md
+++ b/README.md
@@ -1230,12 +1230,10 @@ Besides, you have the ability to intercept events in plugins and translate them 
 
 ```js
 module.exports = (hermione) => {
-    hermione.intercept(hermione.events.TEST_FAIL, ({event, data}) => {
-        const test = Object.create(data);
-        test.pending = true;
-        test.skipReason = 'intercepted failure';
+    hermione.intercept(hermione.events.TEST_FAIL, ({event, test}) => {
+        test.skip({reason: 'intercepted failure'});
 
-        return {event: hermione.events.TEST_PENDING, data: test};
+        return {event: hermione.events.TEST_PENDING, test};
     });
 
     hermione.on(hermione.events.TEST_FAIL, (test) => {

--- a/lib/runner/test-runner/regular-test-runner.js
+++ b/lib/runner/test-runner/regular-test-runner.js
@@ -10,7 +10,7 @@ module.exports = class RegularTestRunner extends Runner {
     constructor(test, browserAgent) {
         super();
 
-        this._test = Object.create(test);
+        this._test = test.clone();
         this._browserAgent = browserAgent;
         this._browser = null;
     }

--- a/lib/runner/test-runner/skipped-test-runner.js
+++ b/lib/runner/test-runner/skipped-test-runner.js
@@ -7,7 +7,7 @@ module.exports = class SkippedTestRunner extends Runner {
     constructor(test) {
         super();
 
-        this._test = Object.create(test);
+        this._test = test.clone();
     }
 
     run() {

--- a/lib/test-collection.js
+++ b/lib/test-collection.js
@@ -110,7 +110,7 @@ module.exports = class TestCollection {
     }
 
     _mkDisabledTest(test) {
-        return _.extend(Object.create(test), {disabled: true});
+        return _.extend(test.clone(), {disabled: true});
     }
 
     disableTest(fullTitle, browserId) {

--- a/lib/test-reader/test-object/configurable-test-object.js
+++ b/lib/test-reader/test-object/configurable-test-object.js
@@ -10,6 +10,12 @@ class ConfigurableTestObject extends TestObject {
         this.#data = {id, file};
     }
 
+    assign(src) {
+        this.#data = {...src.#data};
+
+        return super.assign(src);
+    }
+
     skip({reason}) {
         this.pending = true;
         this.skipReason = reason;

--- a/lib/test-reader/test-object/hook.js
+++ b/lib/test-reader/test-object/hook.js
@@ -7,6 +7,13 @@ class Hook extends TestObject {
         this.fn = fn;
     }
 
+    clone() {
+        return new Hook({
+            title: this.title,
+            fn: this.fn
+        }).assign(this);
+    }
+
     get type() {
         return 'hook';
     }

--- a/lib/test-reader/test-object/test-object.js
+++ b/lib/test-reader/test-object/test-object.js
@@ -11,6 +11,10 @@ class TestObject {
         this.#title = title;
     }
 
+    assign(src) {
+        return Object.assign(this, src);
+    }
+
     get title() {
         return this.#title;
     }

--- a/lib/test-reader/test-object/test.js
+++ b/lib/test-reader/test-object/test.js
@@ -7,6 +7,15 @@ class Test extends ConfigurableTestObject {
         this.fn = fn;
     }
 
+    clone() {
+        return new Test({
+            title: this.title,
+            file: this.file,
+            id: this.id,
+            fn: this.fn
+        }).assign(this);
+    }
+
     get type() {
         return 'test';
     }

--- a/lib/worker/runner/test-runner/hook-runner.js
+++ b/lib/worker/runner/test-runner/hook-runner.js
@@ -32,7 +32,7 @@ module.exports = class HookRunner {
     }
 
     _runHook(hook) {
-        return this._executionThread.run(Object.create(hook));
+        return this._executionThread.run(hook.clone());
     }
 
     async runAfterEachHooks() {

--- a/lib/worker/runner/test-runner/index.js
+++ b/lib/worker/runner/test-runner/index.js
@@ -12,12 +12,8 @@ module.exports = class TestRunner {
     }
 
     constructor(test, config, browserAgent) {
-        this._test = _.cloneDeepWith(test, (val, key) => {
-            // Don't clone whole tree
-            if (key === 'parent') {
-                return val;
-            }
-        });
+        this._test = test.clone();
+        this._test.hermioneCtx = _.cloneDeep(test.hermioneCtx);
 
         this._config = config;
         this._browserAgent = browserAgent;

--- a/test/lib/runner/test-runner/index.js
+++ b/test/lib/runner/test-runner/index.js
@@ -4,8 +4,9 @@ const TestRunner = require('lib/runner/test-runner');
 const SkippedTestRunner = require('lib/runner/test-runner/skipped-test-runner');
 const InsistantTestRunner = require('lib/runner/test-runner/insistant-test-runner');
 const BrowserAgent = require('lib/runner/browser-agent');
+const {Test} = require('lib/test-reader/test-object');
 
-const {makeConfigStub, makeTest} = require('../../../utils');
+const {makeConfigStub} = require('../../../utils');
 
 describe('runner/test-runner', () => {
     const sandbox = sinon.sandbox.create();
@@ -14,7 +15,7 @@ describe('runner/test-runner', () => {
 
     it('should create skipped test runner for skipped test', () => {
         sandbox.spy(SkippedTestRunner, 'create');
-        const test = makeTest();
+        const test = new Test({});
         test.pending = true;
 
         const runner = TestRunner.create(test);
@@ -25,7 +26,7 @@ describe('runner/test-runner', () => {
 
     it('should create skipped test runner for disabled test', () => {
         sandbox.spy(SkippedTestRunner, 'create');
-        const test = makeTest();
+        const test = new Test({});
         test.disabled = true;
 
         const runner = TestRunner.create(test);
@@ -37,7 +38,7 @@ describe('runner/test-runner', () => {
     it('should create insistant test runner for regular test', () => {
         sandbox.spy(InsistantTestRunner, 'create');
 
-        const test = makeTest();
+        const test = new Test({});
         const config = makeConfigStub();
         const browserAgent = BrowserAgent.create();
 

--- a/test/lib/runner/test-runner/insistant-test-runner.js
+++ b/test/lib/runner/test-runner/insistant-test-runner.js
@@ -7,8 +7,9 @@ const Events = require('lib/constants/runner-events');
 const BrowserAgent = require('lib/runner/browser-agent');
 const AssertViewError = require('lib/browser/commands/assert-view/errors/assert-view-error');
 const NoRefImageError = require('lib/browser/commands/assert-view/errors/no-ref-image-error');
+const {Test} = require('lib/test-reader/test-object');
 
-const {makeConfigStub, makeTest} = require('../../../utils');
+const {makeConfigStub} = require('../../../utils');
 
 describe('runner/test-runner/insistant-test-runner', () => {
     const sandbox = sinon.sandbox.create();
@@ -20,7 +21,7 @@ describe('runner/test-runner/insistant-test-runner', () => {
     };
 
     const mkRunner_ = (opts = {}) => {
-        const test = opts.test || makeTest({title: 'defaultTest'});
+        const test = opts.test || new Test({title: 'default test'});
         const config = opts.config || makeConfigStub();
 
         const browserId = Object.keys(config.browsers)[0];
@@ -52,7 +53,7 @@ describe('runner/test-runner/insistant-test-runner', () => {
     };
 
     const makeFailedTest_ = () => {
-        return makeTest({err: new Error()});
+        return Object.assign(new Test({}), {err: new Error()});
     };
 
     beforeEach(() => {
@@ -66,7 +67,7 @@ describe('runner/test-runner/insistant-test-runner', () => {
 
     describe('run', () => {
         it('should run test in regular test runner', async () => {
-            const test = makeTest();
+            const test = new Test({});
             const config = makeConfigStub();
             const browserAgent = BrowserAgent.create();
 
@@ -90,7 +91,7 @@ describe('runner/test-runner/insistant-test-runner', () => {
                 const runner = mkRunner_()
                     .on(Events[event], onEvent);
 
-                const test = makeTest();
+                const test = new Test({});
                 onEachTestRun_((innerRunner) => innerRunner.emit(Events[event], test));
 
                 await run_({runner});
@@ -238,7 +239,7 @@ describe('runner/test-runner/insistant-test-runner', () => {
 
                 it('should not retry assert view fail with NoRefImageError', async () => {
                     onEachTestRun_((innerRunner) => {
-                        const test = makeTest();
+                        const test = new Test({});
                         test.err = new AssertViewError();
                         test.assertViewResults = [new NoRefImageError()];
 
@@ -252,7 +253,7 @@ describe('runner/test-runner/insistant-test-runner', () => {
 
                 it('should retry regular fail with NoRefImageError in assert view results', async () => {
                     onFirstTestRun_((innerRunner) => {
-                        const test = makeTest();
+                        const test = new Test({});
                         test.err = new Error();
                         test.assertViewResults = [new NoRefImageError()];
 

--- a/test/lib/test-collection.js
+++ b/test/lib/test-collection.js
@@ -1,6 +1,7 @@
 'use strict';
 
 const TestCollection = require('lib/test-collection');
+const {Test} = require('lib/test-reader/test-object');
 
 describe('test-collection', () => {
     describe('getBrowsers', () => {
@@ -215,9 +216,9 @@ describe('test-collection', () => {
 
     describe('disableAll', () => {
         it('should disable all tests', () => {
-            const test1 = {title: 'test1'};
-            const test2 = {title: 'test2'};
-            const test3 = {title: 'test3'};
+            const test1 = new Test({title: 'test1'});
+            const test2 = new Test({title: 'test2'});
+            const test3 = new Test({title: 'test3'});
 
             const collection = TestCollection.create({
                 'bro1': [test1],
@@ -226,20 +227,13 @@ describe('test-collection', () => {
 
             collection.disableAll();
 
-            assert.deepEqual(
-                collection.mapTests((t) => t),
-                [
-                    {title: 'test1', disabled: true},
-                    {title: 'test2', disabled: true},
-                    {title: 'test3', disabled: true}
-                ]
-            );
+            collection.eachTest((t) => assert.propertyVal(t, 'disabled', true));
         });
 
         it('should disable all tests for specified browser', () => {
-            const test1 = {title: 'test1'};
-            const test2 = {title: 'test2'};
-            const test3 = {title: 'test3'};
+            const test1 = new Test({title: 'test1'});
+            const test2 = new Test({title: 'test2'});
+            const test3 = new Test({title: 'test3'});
 
             const collection = TestCollection.create({
                 'bro1': [test1],
@@ -248,19 +242,8 @@ describe('test-collection', () => {
 
             collection.disableAll('bro1');
 
-            assert.deepEqual(
-                collection.mapTests('bro1', (t) => t),
-                [
-                    {title: 'test1', disabled: true}
-                ]
-            );
-            assert.deepEqual(
-                collection.mapTests('bro2', (t) => t),
-                [
-                    {title: 'test2'},
-                    {title: 'test3'}
-                ]
-            );
+            collection.eachTest('bro1', (t) => assert.propertyVal(t, 'disabled', true));
+            collection.eachTest('bro2', (t) => assert.propertyVal(t, 'disabled', false));
         });
 
         it('should be chainable', () => {
@@ -272,7 +255,7 @@ describe('test-collection', () => {
 
     describe('enableAll', () => {
         it('should do nothing for tests which were not disabled', () => {
-            const test = {title: 'test'};
+            const test = new Test({title: 'test'});
 
             const collection = TestCollection.create({
                 'bro': [test]
@@ -280,17 +263,12 @@ describe('test-collection', () => {
 
             collection.enableAll();
 
-            assert.deepEqual(
-                collection.mapTests((t) => t),
-                [
-                    {title: 'test'}
-                ]
-            );
+            collection.eachTest((t) => assert.propertyVal(t, 'disabled', false));
         });
 
         it('should enable all previously disabled tests', () => {
-            const test1 = {title: 'test1'};
-            const test2 = {title: 'test2'};
+            const test1 = new Test({title: 'test1'});
+            const test2 = new Test({title: 'test2'});
 
             const collection = TestCollection.create({
                 'bro1': [test1],
@@ -300,17 +278,12 @@ describe('test-collection', () => {
             collection.disableAll();
             collection.enableAll();
 
-            assert.deepEqual(
-                collection.mapTests((t) => t),
-                [
-                    {title: 'test1'},
-                    {title: 'test2'}
-                ]
-            );
+            collection.eachTest((t) => assert.propertyVal(t, 'disabled', false));
         });
 
         it('should not enable tests which were originally disabled', () => {
-            const test = {title: 'test', disabled: true};
+            const test = new Test({title: 'test'});
+            test.disable();
 
             const collection = TestCollection.create({
                 'bro': [test]
@@ -319,17 +292,12 @@ describe('test-collection', () => {
             collection.disableAll();
             collection.enableAll();
 
-            assert.deepEqual(
-                collection.mapTests((t) => t),
-                [
-                    {title: 'test', disabled: true}
-                ]
-            );
+            collection.eachTest((t) => assert.propertyVal(t, 'disabled', true));
         });
 
         it('should enable all previously disabled tests for passed browser', () => {
-            const test1 = {title: 'test1'};
-            const test2 = {title: 'test2'};
+            const test1 = new Test({title: 'test1'});
+            const test2 = new Test({title: 'test2'});
 
             const collection = TestCollection.create({
                 'bro1': [test1],
@@ -339,13 +307,8 @@ describe('test-collection', () => {
             collection.disableAll();
             collection.enableAll('bro2');
 
-            assert.deepEqual(
-                collection.mapTests((t) => t),
-                [
-                    {title: 'test1', disabled: true},
-                    {title: 'test2'}
-                ]
-            );
+            collection.eachTest('bro1', (t) => assert.propertyVal(t, 'disabled', true));
+            collection.eachTest('bro2', (t) => assert.propertyVal(t, 'disabled', false));
         });
 
         it('should be chainable', () => {
@@ -358,8 +321,8 @@ describe('test-collection', () => {
     describe('disableTest', () => {
         it('should disable test in all browsers', () => {
             const collection = TestCollection.create({
-                'bro1': [{fullTitle: () => 'foo bar'}],
-                'bro2': [{fullTitle: () => 'foo bar'}]
+                'bro1': [new Test({title: 'foo bar'})],
+                'bro2': [new Test({title: 'foo bar'})]
             });
 
             collection.disableTest('foo bar');
@@ -372,8 +335,8 @@ describe('test-collection', () => {
 
         it('should disable test in specified browser', () => {
             const collection = TestCollection.create({
-                'bro1': [{fullTitle: () => 'foo bar'}],
-                'bro2': [{fullTitle: () => 'foo bar'}]
+                'bro1': [new Test({title: 'foo bar'})],
+                'bro2': [new Test({title: 'foo bar'})]
             });
 
             collection.disableTest('foo bar', 'bro1');
@@ -384,8 +347,8 @@ describe('test-collection', () => {
 
         it('should disable test in all browsers where it exists', () => {
             const collection = TestCollection.create({
-                'bro1': [{fullTitle: () => 'foo bar'}],
-                'bro2': [{fullTitle: () => 'baz qux'}]
+                'bro1': [new Test({title: 'foo bar'})],
+                'bro2': [new Test({title: 'baz qux'})]
             });
 
             collection.disableTest('foo bar');
@@ -404,7 +367,7 @@ describe('test-collection', () => {
     describe('enableTest', () => {
         it('should do nothing for tests which were not disabled', () => {
             const collection = TestCollection.create({
-                'bro': [{fullTitle: () => 'foo bar'}]
+                'bro': [new Test({title: 'foo bar'})]
             });
 
             collection
@@ -419,8 +382,8 @@ describe('test-collection', () => {
 
         it('should enable test in all browsers', () => {
             const collection = TestCollection.create({
-                'bro1': [{fullTitle: () => 'foo bar'}],
-                'bro2': [{fullTitle: () => 'foo bar'}]
+                'bro1': [new Test({title: 'foo bar'})],
+                'bro2': [new Test({title: 'foo bar'})]
             });
 
             collection
@@ -435,7 +398,7 @@ describe('test-collection', () => {
 
         it('should enable previously disabled single test', () => {
             const collection = TestCollection.create({
-                'bro': [{fullTitle: () => 'foo bar'}]
+                'bro': [new Test({title: 'foo bar'})]
             });
 
             collection
@@ -447,7 +410,7 @@ describe('test-collection', () => {
 
         it('should enable test even if it was disabled twice', () => {
             const collection = TestCollection.create({
-                'bro': [{fullTitle: () => 'foo bar'}]
+                'bro': [new Test({title: 'foo bar'})]
             });
 
             collection
@@ -460,8 +423,8 @@ describe('test-collection', () => {
 
         it('should enable test in specified browser', () => {
             const collection = TestCollection.create({
-                'bro1': [{fullTitle: () => 'foo bar'}],
-                'bro2': [{fullTitle: () => 'foo bar'}]
+                'bro1': [new Test({title: 'foo bar'})],
+                'bro2': [new Test({title: 'foo bar'})]
             });
 
             collection

--- a/test/lib/test-reader/test-object/configurable-test-object.js
+++ b/test/lib/test-reader/test-object/configurable-test-object.js
@@ -44,6 +44,42 @@ describe('test-reader/test-object/configurable-test-object', () => {
         });
     });
 
+    describe('assign', () => {
+        it('should return itself', () => {
+            const obj = mkObj_();
+
+            assert.equal(obj.assign(mkObj_()), obj);
+        });
+
+        it('should call base class assign method', () => {
+            sandbox.spy(TestObject.prototype, 'assign');
+            const src = mkObj_();
+
+            mkObj_().assign(src);
+
+            assert.calledOnceWith(TestObject.prototype.assign, src);
+        });
+
+        [
+            ['pending', true],
+            ['skipReason', 'foo bar'],
+            ['disabled', true],
+            ['silentSkip', true],
+            ['timeout', 100500],
+            ['browserId', 'foo'],
+            ['browserVersion', '100500']
+        ].forEach(([property, value]) => {
+            it(`should assign ${property} property value`, () => {
+                const src = mkObj_();
+                src[property] = value;
+
+                const obj = mkObj_().assign(src);
+
+                assert.propertyVal(obj, property, value);
+            });
+        });
+    });
+
     describe('id', () => {
         it('should return object id', () => {
             const obj = mkObj_({id: 'foo'});

--- a/test/lib/test-reader/test-object/hook.js
+++ b/test/lib/test-reader/test-object/hook.js
@@ -55,6 +55,33 @@ describe('test-reader/test-object/hook', () => {
         });
     });
 
+    describe('clone', () => {
+        it('should return an instance of Hook', () => {
+            const clonedHook = new Hook({}).clone();
+
+            assert.instanceOf(clonedHook, Hook);
+        });
+
+        it('should create object with same own properties', () => {
+            const fn = sinon.spy();
+
+            const clonedHook = new Hook({title: 'foo bar', fn});
+
+            assert.equal(clonedHook.fn, fn);
+            assert.equal(clonedHook.title, 'foo bar');
+        });
+
+        it('should assign itself to cloned object', () => {
+            sandbox.spy(Hook.prototype, 'assign');
+            const hook = new Hook({});
+
+            const clonedHook = hook.clone();
+
+            assert.calledOnceWith(Hook.prototype.assign, hook);
+            assert.calledOn(Hook.prototype.assign, clonedHook);
+        });
+    });
+
     describe('type', () => {
         it('should be "hook"', () => {
             const hook = new Hook({});

--- a/test/lib/test-reader/test-object/test-object.js
+++ b/test/lib/test-reader/test-object/test-object.js
@@ -3,6 +3,27 @@
 const {TestObject} = require('lib/test-reader/test-object/test-object');
 
 describe('test-reader/test-object/test-object', () => {
+    describe('assign', () => {
+        it('should return itself', () => {
+            const obj = new TestObject({});
+
+            assert.equal(obj.assign(new TestObject({})), obj);
+        });
+
+        it('should assign source properties', () => {
+            const src = new TestObject({});
+            src.foo = 'bar';
+
+            const baz = {qux: 100500};
+            src.baz = baz;
+
+            const obj = new TestObject({}).assign(src);
+
+            assert.equal(obj.foo, 'bar');
+            assert.equal(obj.baz, baz);
+        });
+    });
+
     describe('title', () => {
         it('should return object title', () => {
             const obj = new TestObject({title: 'foo bar'});

--- a/test/lib/test-reader/test-object/test.js
+++ b/test/lib/test-reader/test-object/test.js
@@ -50,6 +50,35 @@ describe('test-reader/test-object/test', () => {
         });
     });
 
+    describe('clone', () => {
+        it('should return an instance of Test', () => {
+            const clonedTest = new Test({}).clone();
+
+            assert.instanceOf(clonedTest, Test);
+        });
+
+        it('should create object with same own properties', () => {
+            const fn = sinon.spy();
+
+            const clonedTest = new Test({title: 'foo bar', file: 'foo/bar', id: 'foobar', fn});
+
+            assert.equal(clonedTest.fn, fn);
+            assert.equal(clonedTest.title, 'foo bar');
+            assert.equal(clonedTest.file, 'foo/bar');
+            assert.equal(clonedTest.id, 'foobar');
+        });
+
+        it('should assign itself to cloned object', () => {
+            sandbox.spy(Test.prototype, 'assign');
+            const test = new Test({});
+
+            const clonedTest = test.clone();
+
+            assert.calledOnceWith(Test.prototype.assign, test);
+            assert.calledOn(Test.prototype.assign, clonedTest);
+        });
+    });
+
     describe('type', () => {
         it('should be "test"', () => {
             const test = new Test({});


### PR DESCRIPTION
Inheritance through `Object.create` doesn't work wery well with inheritance through `extends`