### PR TITLE
fix: use undefined as a default value for browserVersion and browserId properties

### DIFF
--- a/lib/test-reader/test-object/configurable-test-object.js
+++ b/lib/test-reader/test-object/configurable-test-object.js
@@ -82,7 +82,7 @@ class ConfigurableTestObject extends TestObject {
     }
 
     get browserId() {
-        return this.#getInheritedProperty('browserId', '');
+        return this.#getInheritedProperty('browserId', undefined);
     }
 
     set browserVersion(version) {
@@ -90,17 +90,17 @@ class ConfigurableTestObject extends TestObject {
     }
 
     get browserVersion() {
-        return this.#getInheritedProperty('browserVersion', '');
+        return this.#getInheritedProperty('browserVersion', undefined);
     }
 
     get hasBrowserVersionOverwritten() {
-        return Boolean(this.#data.browserVersion);
+        return ('browserVersion' in this.#data);
     }
 
     #getInheritedProperty(name, defaultValue) {
-        return this.#data[name] === undefined
-            ? _.get(this.parent, name, defaultValue)
-            : this.#data[name];
+        return name in this.#data
+            ? this.#data[name]
+            : _.get(this.parent, name, defaultValue);
     }
 }
 

--- a/test/lib/test-reader/test-object/configurable-test-object.js
+++ b/test/lib/test-reader/test-object/configurable-test-object.js
@@ -150,8 +150,8 @@ describe('test-reader/test-object/configurable-test-object', () => {
         ['disabled', false, true, false],
         ['silentSkip', false, true, false],
         ['timeout', 0, 100500, 500100],
-        ['browserId', '', 'foo', 'bar'],
-        ['browserVersion', '', '100500', '500100']
+        ['browserId', undefined, 'foo', 'bar'],
+        ['browserVersion', undefined, '100500', '500100']
     ].forEach(([property, defaultValue, testValue, valueToOverwrite]) => {
         describe(property, () => {
             it('should return default value if no parent', () => {
@@ -196,18 +196,6 @@ describe('test-reader/test-object/configurable-test-object', () => {
                 obj[property] = defaultValue;
 
                 assert.equal(obj[property], defaultValue);
-            });
-
-            it('should use parent value if current is set to undefined', () => {
-                const obj = mkObj_();
-                const parent = mkObj_();
-                obj.parent = parent;
-
-                parent[property] = testValue;
-                obj[property] = valueToOverwrite;
-                obj[property] = undefined;
-
-                assert.equal(obj[property], testValue);
             });
         });
     });


### PR DESCRIPTION
html-reporter gui expects `undefined` for `browserVersion` property