### PR TITLE
feat: support tests and config on typescript

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -53,7 +53,9 @@
         "@types/chai-as-promised": "^7.1.5",
         "@types/lodash": "^4.14.191",
         "@types/node": "^12.20.28",
+        "@types/proxyquire": "^1.3.28",
         "@types/sharp": "^0.31.1",
+        "@types/sinon": "^4.3.3",
         "app-module-path": "^2.2.0",
         "chai": "^4.1.1",
         "chai-as-promised": "^7.1.1",
@@ -76,6 +78,14 @@
       },
       "engines": {
         "node": ">= 14.0.0"
+      },
+      "peerDependencies": {
+        "ts-node": ">=10.5.0"
+      },
+      "peerDependenciesMeta": {
+        "ts-node": {
+          "optional": true
+        }
       }
     },
     "node_modules/@ampproject/remapping": {
@@ -1899,6 +1909,12 @@
       "integrity": "sha512-//oorEZjL6sbPcKUaCdIGlIUeH26mgzimjBB77G6XRgnDl/L5wOnpyBGRe/Mmf5CVW3PwEBE1NjiMZ/ssFh4wA==",
       "dev": true
     },
+    "node_modules/@types/proxyquire": {
+      "version": "1.3.28",
+      "resolved": "https://registry.npmjs.org/@types/proxyquire/-/proxyquire-1.3.28.tgz",
+      "integrity": "sha512-SQaNzWQ2YZSr7FqAyPPiA3FYpux2Lqh3HWMZQk47x3xbMCqgC/w0dY3dw9rGqlweDDkrySQBcaScXWeR+Yb11Q==",
+      "dev": true
+    },
     "node_modules/@types/responselike": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/@types/responselike/-/responselike-1.0.0.tgz",
@@ -1915,6 +1931,12 @@
       "dependencies": {
         "@types/node": "*"
       }
+    },
+    "node_modules/@types/sinon": {
+      "version": "4.3.3",
+      "resolved": "https://registry.npmjs.org/@types/sinon/-/sinon-4.3.3.tgz",
+      "integrity": "sha512-Tt7w/ylBS/OEAlSCwzB0Db1KbxnkycP/1UkQpbvKFYoUuRn4uYsC3xh5TRPrOjTy0i8TIkSz1JdNL4GPVdf3KQ==",
+      "dev": true
     },
     "node_modules/@types/stack-utils": {
       "version": "2.0.1",
@@ -13735,6 +13757,12 @@
       "integrity": "sha512-//oorEZjL6sbPcKUaCdIGlIUeH26mgzimjBB77G6XRgnDl/L5wOnpyBGRe/Mmf5CVW3PwEBE1NjiMZ/ssFh4wA==",
       "dev": true
     },
+    "@types/proxyquire": {
+      "version": "1.3.28",
+      "resolved": "https://registry.npmjs.org/@types/proxyquire/-/proxyquire-1.3.28.tgz",
+      "integrity": "sha512-SQaNzWQ2YZSr7FqAyPPiA3FYpux2Lqh3HWMZQk47x3xbMCqgC/w0dY3dw9rGqlweDDkrySQBcaScXWeR+Yb11Q==",
+      "dev": true
+    },
     "@types/responselike": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/@types/responselike/-/responselike-1.0.0.tgz",
@@ -13751,6 +13779,12 @@
       "requires": {
         "@types/node": "*"
       }
+    },
+    "@types/sinon": {
+      "version": "4.3.3",
+      "resolved": "https://registry.npmjs.org/@types/sinon/-/sinon-4.3.3.tgz",
+      "integrity": "sha512-Tt7w/ylBS/OEAlSCwzB0Db1KbxnkycP/1UkQpbvKFYoUuRn4uYsC3xh5TRPrOjTy0i8TIkSz1JdNL4GPVdf3KQ==",
+      "dev": true
     },
     "@types/stack-utils": {
       "version": "2.0.1",

--- a/package.json
+++ b/package.json
@@ -82,7 +82,9 @@
     "@types/chai-as-promised": "^7.1.5",
     "@types/lodash": "^4.14.191",
     "@types/node": "^12.20.28",
+    "@types/proxyquire": "^1.3.28",
     "@types/sharp": "^0.31.1",
+    "@types/sinon": "^4.3.3",
     "app-module-path": "^2.2.0",
     "chai": "^4.1.1",
     "chai-as-promised": "^7.1.1",
@@ -102,5 +104,13 @@
     "standard-version": "^9.5.0",
     "ts-node": "^10.9.1",
     "typescript": "^4.9.5"
+  },
+  "peerDependencies": {
+    "ts-node": ">=10.5.0"
+  },
+  "peerDependenciesMeta": {
+    "ts-node": {
+      "optional": true
+    }
   }
 }

--- a/src/base-hermione.js
+++ b/src/base-hermione.js
@@ -9,6 +9,7 @@ const RunnerEvents = require('./constants/runner-events');
 const AsyncEmitter = require('./events/async-emitter');
 const Errors = require('./errors');
 const WorkerRunnerEvents = require('./worker/constants/runner-events');
+const {tryToRegisterTsNode} = require('./utils/typescript');
 
 const PREFIX = require('../package').name + '-';
 
@@ -21,6 +22,8 @@ module.exports = class BaseHermione extends AsyncEmitter {
         super();
 
         this._interceptors = [];
+
+        tryToRegisterTsNode();
 
         this._config = Config.create(config);
         this._loadPlugins();

--- a/src/config/defaults.js
+++ b/src/config/defaults.js
@@ -6,7 +6,6 @@ module.exports = {
     baseUrl: 'http://localhost',
     gridUrl: 'http://localhost:4444/wd/hub',
     browserWSEndpoint: null,
-    config: '.hermione.conf.js',
     desiredCapabilities: null,
     automationProtocol: WEBDRIVER_PROTOCOL,
     sessionEnvFlags: {},
@@ -74,7 +73,7 @@ module.exports = {
     resetCursor: true,
     strictTestsOrder: false,
     saveHistoryMode: SAVE_HISTORY_MODE.ALL,
-    fileExtensions: ['.js', '.mjs'],
+    fileExtensions: ['.js', '.mjs', '.ts', '.mts'],
     outputDir: null,
     agent: null,
     headers: null,
@@ -86,3 +85,5 @@ module.exports = {
     region: null,
     headless: null
 };
+
+module.exports.configPaths = ['.hermione.conf.ts', '.hermione.conf.js'];

--- a/src/utils/typescript.ts
+++ b/src/utils/typescript.ts
@@ -1,0 +1,26 @@
+import _ from 'lodash';
+
+export const tryToRegisterTsNode = (): void => {
+    try {
+        const {REGISTER_INSTANCE} = require('ts-node');
+
+        if (Boolean(_.get(process, REGISTER_INSTANCE))) {
+            return;
+        }
+
+        const {register}: typeof import('ts-node') = require('ts-node');
+        let swc = false;
+
+        try {
+            require('@swc/core');
+            swc = true;
+        } catch {}
+
+        register({
+            skipProject: JSON.parse(process.env.TS_NODE_SKIP_PROJECT ?? 'true'),
+            transpileOnly: JSON.parse(process.env.TS_NODE_TRANSPILE_ONLY ?? 'true'),
+            swc: JSON.parse(process.env.TS_NODE_SWC ?? swc.toString())
+        });
+
+    } catch {}
+}

--- a/test/lib/config/browser-options.js
+++ b/test/lib/config/browser-options.js
@@ -15,7 +15,7 @@ describe('config browser-options', () => {
         });
     };
 
-    const createConfig = () => Config.create(defaults.config);
+    const createConfig = () => Config.create('some-config-path');
 
     beforeEach(() => {
         sandbox.stub(Config, 'read').returns({});

--- a/test/lib/config/options.js
+++ b/test/lib/config/options.js
@@ -9,7 +9,7 @@ const {MissingOptionError} = require('gemini-configparser');
 describe('config options', () => {
     const sandbox = sinon.sandbox.create();
 
-    const createConfig = () => Config.create(defaults.config);
+    const createConfig = () => Config.create('some-config-path');
 
     const parse_ = (opts = {}) => parser({env: {}, argv: [], ...opts});
 

--- a/test/lib/utils/typescript.ts
+++ b/test/lib/utils/typescript.ts
@@ -1,0 +1,91 @@
+import proxyquire from 'proxyquire';
+import sinon, { type SinonStub} from 'sinon';
+import _ from 'lodash';
+import * as process from "process";
+
+describe('utils/typescript', () => {
+    let processBackup = _.assign({}, process);
+    let processEnvBackup = _.assign({}, process.env);
+
+    let ts: typeof import('src/utils/typescript');
+    let registerStub: SinonStub;
+    const REGISTER_INSTANCE = Symbol("tsNodeTesting");
+
+    beforeEach(() => {
+        registerStub = sinon.stub();
+        ts = require('src/utils/typescript');
+        ts = proxyquire('src/utils/typescript', {
+            'ts-node': {
+                register: registerStub,
+                REGISTER_INSTANCE
+            },
+        });
+    });
+
+    afterEach(() => {
+        _.set(process, REGISTER_INSTANCE, undefined);
+        _.set(global, 'process', processBackup);
+        _.set(process, 'env', processEnvBackup);
+    });
+
+    describe('tryToRegisterTsNode', () => {
+        it('should not call register if typescript was already installed', () => {
+            _.set(global, ['process', REGISTER_INSTANCE], true);
+
+            ts.tryToRegisterTsNode();
+
+            assert.notCalled(registerStub);
+        });
+
+        it('should respect env vars', () => {
+            process.env.TS_NODE_SKIP_PROJECT = 'false';
+            process.env.TS_NODE_TRANSPILE_ONLY = 'false';
+
+            ts.tryToRegisterTsNode();
+
+            assert.calledOnceWith(registerStub, sinon.match({
+                skipProject: false,
+                transpileOnly: false,
+            }));
+        });
+
+        it('should use swc if it is installed', () => {
+            ts = proxyquire('src/utils/typescript', {
+                'ts-node': {
+                    register: registerStub
+                },
+                '@swc/core': sinon.stub(),
+            });
+
+            ts.tryToRegisterTsNode();
+
+            assert.calledOnceWith(registerStub, sinon.match({
+                swc: true
+            }));
+        });
+
+        it('should not use swc if not installed', () => {
+            ts = proxyquire('src/utils/typescript', {
+                'ts-node': {
+                    register: registerStub
+                },
+                '@swc/core': null,
+            });
+
+            ts.tryToRegisterTsNode();
+
+            assert.calledOnceWith(registerStub, sinon.match({
+                swc: undefined
+            }));
+        });
+
+        it('should not throw if nothing is installed', () => {
+            ts = proxyquire('src/utils/typescript', {
+                'ts-node': null,
+                '@swc/core': null,
+            });
+
+            assert.doesNotThrow(() => ts.tryToRegisterTsNode());
+        });
+    });
+});

--- a/test/types.ts
+++ b/test/types.ts
@@ -1,6 +1,9 @@
-import "chai-as-promised";
+import 'chai-as-promised';
 import Assert = Chai.Assert; // eslint-disable-line no-undef
+import {SinonAssert} from 'sinon';
+
 
 declare global {
-    const assert: typeof import("chai").assert & Assert;
+    const assert: typeof import('chai').assert & SinonAssert & Assert &
+        { calledOnceWith(...args: any[]): boolean };
 }


### PR DESCRIPTION
### Что сделано?
- Hermione теперь умеет читать конфиг и тесты на typescript
- Проведено исследование производительности
- Опробовано множество вариантов, финальный – использование `ts-node` с возможностью ускорения путем установки `@swc/core`

### Принятые решения
- `ts-node` сделал optional peerDependency, так делает, например, jest
- `@swc/core` вообще нигде не фигурирует в зависимостях, просто подхватится автоматически, если пользователь установит. Планирую отразить это в доке, буду обновлять доку после последнего чанка интеграции с TS – правок тайпингов
- Проверка типов при запуске тестов не производится
- По умолчанию пни чтении вообще не используется tsconfig проекта – в целом, при отсутствии проверки типов конфигурация особо не нужна (на что-то влияет только target и module). Но при желании с помощью переменных окружения и других средств, которые поддерживает ts-node, это можно менять

### Как я тестировал?
- Поднял тестовый проект с тестами на ts/js, пробовал конфиг ts/js, пробовал без ts-node, с ts-node, с ts-node+@swc/core

⚠️ Перед влитием планирую обновить package-lock.json. Тесты сейчас падают из-за этого.