### PR TITLE
fix: correctly screen elements on device with fractional pixel ratio

### DIFF
--- a/src/browser/camera/index.js
+++ b/src/browser/camera/index.js
@@ -59,10 +59,10 @@ module.exports = class Camera {
         }
 
         return {
-            left: (imageArea.left + cropArea.left) * page.pixelRatio,
-            top: (imageArea.top + cropArea.top) * page.pixelRatio,
-            width: Math.min(imageArea.width - cropArea.left, cropArea.width) * page.pixelRatio,
-            height: Math.min(imageArea.height - cropArea.top, cropArea.height) * page.pixelRatio,
+            left: imageArea.left + cropArea.left,
+            top: imageArea.top + cropArea.top,
+            width: Math.min(imageArea.width - cropArea.left, cropArea.width),
+            height: Math.min(imageArea.height - cropArea.top, cropArea.height),
         };
     }
 };

--- a/src/browser/camera/utils.js
+++ b/src/browser/camera/utils.js
@@ -22,9 +22,5 @@ exports.isFullPage = (imageArea, page, screenshotMode) => {
  * @private
  */
 function compareDimensions(imageArea, page) {
-    const pixelRatio = page.pixelRatio;
-    const documentWidth = page.documentWidth * pixelRatio;
-    const documentHeight = page.documentHeight * pixelRatio;
-
-    return imageArea.height >= documentHeight && imageArea.width >= documentWidth;
+    return imageArea.height >= page.documentHeight && imageArea.width >= page.documentWidth;
 }

--- a/src/browser/client-scripts/rect.js
+++ b/src/browser/client-scripts/rect.js
@@ -86,6 +86,17 @@ Rect.prototype = {
         });
     },
 
+    scale: function (scaleFactor) {
+        var rect = new Rect({
+            top: this.top * scaleFactor,
+            left: this.left * scaleFactor,
+            right: this.right * scaleFactor,
+            bottom: this.bottom * scaleFactor
+        });
+
+        return util.isInteger(scaleFactor) ? rect : rect.round();
+    },
+
     serialize: function () {
         return {
             left: this.left,
@@ -138,7 +149,15 @@ Rect.prototype = {
 };
 
 exports.Rect = Rect;
-exports.getAbsoluteClientRect = function getAbsoluteClientRect(element, scrollElem) {
-    var clientRect = new Rect(element.getBoundingClientRect());
-    return clientRect.translate(util.getScrollLeft(scrollElem), util.getScrollTop(scrollElem));
+exports.getAbsoluteClientRect = function getAbsoluteClientRect(element, opts) {
+    var coords = element.getBoundingClientRect();
+    var clientRect = new Rect({
+        left: coords.left,
+        top: coords.top,
+        // to correctly calculate "width" in devices with fractional pixelRatio
+        width: coords.width % opts.viewportWidth < 1 ? opts.viewportWidth : coords.width,
+        height: Math.min(coords.height, opts.documentHeight)
+    });
+
+    return clientRect.translate(util.getScrollLeft(opts.scrollElem), util.getScrollTop(opts.scrollElem));
 };

--- a/src/browser/client-scripts/util.js
+++ b/src/browser/client-scripts/util.js
@@ -84,3 +84,7 @@ exports.isSafariMobile = function () {
         /(iPhone|iPad).*AppleWebKit.*Safari/i.test(navigator.userAgent)
     );
 };
+
+exports.isInteger = function (num) {
+    return num % 1 === 0;
+};

--- a/src/browser/screen-shooter/index.js
+++ b/src/browser/screen-shooter/index.js
@@ -36,14 +36,15 @@ module.exports = class ScreenShooter {
     }
 
     async _extendImage(viewport, page, opts) {
-        const scrollHeight = Math.min(viewport.getVerticalOverflow(), page.viewport.height);
+        const physicalScrollHeight = Math.min(viewport.getVerticalOverflow(), page.viewport.height);
+        const logicalScrollHeight = Math.ceil(physicalScrollHeight / page.pixelRatio);
 
-        await this._browser.scrollBy({ x: 0, y: scrollHeight, selector: opts.selectorToScroll });
+        await this._browser.scrollBy({ x: 0, y: logicalScrollHeight, selector: opts.selectorToScroll });
 
-        page.viewport.top += scrollHeight;
+        page.viewport.top += physicalScrollHeight;
 
         const newImage = await this._browser.captureViewportImage(page, opts.screenshotDelay);
 
-        await viewport.extendBy(scrollHeight, newImage);
+        await viewport.extendBy(physicalScrollHeight, newImage);
     }
 };

--- a/src/browser/screen-shooter/viewport/index.js
+++ b/src/browser/screen-shooter/viewport/index.js
@@ -10,10 +10,9 @@ module.exports = class Viewport {
     }
 
     constructor(page, image, opts) {
-        this._pixelRatio = page.pixelRatio;
-        this._viewport = this._scale(page.viewport);
-        this._captureArea = this._scale(this._sanitize(page.captureArea));
-        this._ignoreAreas = page.ignoreAreas.map(area => this._scale(area));
+        this._viewport = _.clone(page.viewport);
+        this._captureArea = this._sanitize(page.captureArea);
+        this._ignoreAreas = page.ignoreAreas;
         this._image = image;
         this._opts = opts;
         this._summaryHeight = 0;
@@ -58,8 +57,7 @@ module.exports = class Viewport {
         return this._image.save(path);
     }
 
-    async extendBy(scrollHeight, newImage) {
-        const physicalScrollHeight = scrollHeight * this._pixelRatio;
+    async extendBy(physicalScrollHeight, newImage) {
         this._viewport.height += physicalScrollHeight;
         const { width, height } = await newImage.getSize();
 
@@ -74,16 +72,7 @@ module.exports = class Viewport {
     }
 
     getVerticalOverflow() {
-        return (getAreaBottom(this._captureArea) - getAreaBottom(this._viewport)) / this._pixelRatio;
-    }
-
-    _scale(area, scaleFactor = this._pixelRatio) {
-        return {
-            left: area.left * scaleFactor,
-            top: area.top * scaleFactor,
-            width: area.width * scaleFactor,
-            height: area.height * scaleFactor,
-        };
+        return getAreaBottom(this._captureArea) - getAreaBottom(this._viewport);
     }
 
     _sanitize(area) {

--- a/test/src/browser/camera/index.js
+++ b/test/src/browser/camera/index.js
@@ -58,7 +58,6 @@ describe("browser/camera", () => {
                     sandbox.stub(utils, "isFullPage");
 
                     page = {
-                        pixelRatio: 1,
                         viewport: {
                             left: 1,
                             top: 1,
@@ -93,19 +92,6 @@ describe("browser/camera", () => {
                         height: page.viewport.height,
                         width: page.viewport.width,
                     });
-                });
-
-                it("should crop considering pixel ratio", async () => {
-                    utils.isFullPage.returns(true);
-
-                    const scaledPage = {
-                        pixelRatio: 2,
-                        viewport: { left: 2, top: 3, width: 10, height: 12 },
-                    };
-
-                    await mkCamera_({ screenshotMode: "fullPage" }).captureViewportImage(scaledPage);
-
-                    assert.calledOnceWith(image.crop, { left: 4, top: 6, width: 20, height: 24 });
                 });
             });
         });

--- a/test/src/browser/screen-shooter/viewport/index.js
+++ b/test/src/browser/screen-shooter/viewport/index.js
@@ -13,7 +13,6 @@ describe("Viewport", () => {
     const createViewport = (opts = {}) =>
         new Viewport(
             {
-                pixelRatio: opts.pixelRatio || 1,
                 captureArea: opts.captureArea || {},
                 viewport: opts.viewport || {},
                 ignoreAreas: opts.ignoreAreas || [],
@@ -99,21 +98,6 @@ describe("Viewport", () => {
             assert.calledOnceWith(image.applyClear);
         });
 
-        it("should consider pixel ratio", async () => {
-            const firstArea = { left: 20, top: 12, width: 30, height: 5 };
-            const secondArea = { left: 12, top: 35, width: 25, height: 15 };
-            const pixelRatio = 2;
-            const viewport = createViewport({
-                ignoreAreas: [firstArea, secondArea],
-                pixelRatio,
-            });
-
-            await viewport.ignoreAreas(image, { left: 0, top: 0, width: 100, height: 100 });
-
-            assert.calledWith(image.addClear.firstCall, { left: 40, top: 24, width: 60, height: 10 });
-            assert.calledWith(image.addClear.secondCall, { left: 24, top: 70, width: 50, height: 30 });
-        });
-
         describe("should crop ignore area to image area", () => {
             it("inside", async () => {
                 const viewport = createViewport({ ignoreAreas: [{ left: 0, top: 0, width: 1000, height: 1000 }] });
@@ -150,7 +134,6 @@ describe("Viewport", () => {
             it("bottom right", async () => {
                 const viewport = createViewport({
                     ignoreAreas: [{ left: 10, top: 10, width: 100, height: 100 }],
-                    pixelRatio: 1,
                 });
 
                 await viewport.ignoreAreas(image, { left: 50, top: 50, width: 100, height: 100 });
@@ -209,32 +192,6 @@ describe("Viewport", () => {
                 await vieport.handleImage(image);
 
                 assert.calledOnceWith(image.crop, { left: 1, top: 2, width: 3, height: 4 });
-            });
-
-            describe("considering pixel ratio", () => {
-                it("without intersection", async () => {
-                    const vieport = createViewport({
-                        captureArea: { left: 1, top: 1, width: 1, height: 1 },
-                        viewport: { left: 0, top: 0, width: 10, height: 10 },
-                        pixelRatio: 3,
-                    });
-
-                    await vieport.handleImage(image);
-
-                    assert.calledOnceWith(image.crop, { left: 3, top: 3, width: 3, height: 3 });
-                });
-
-                it("with intersection", async () => {
-                    const vieport = createViewport({
-                        captureArea: { left: 2, top: 3, width: 4, height: 5 },
-                        viewport: { left: 0, top: 0, width: 10, height: 10 },
-                        pixelRatio: 3,
-                    });
-
-                    await vieport.handleImage(image);
-
-                    assert.calledOnceWith(image.crop, { left: 6, top: 9, width: 1, height: 1 });
-                });
             });
 
             it("with given area", async () => {
@@ -337,12 +294,11 @@ describe("Viewport", () => {
             const viewport = createViewport({
                 captureArea: { left: 0, top: 0, width: 4, height: 20 },
                 viewport: { left: 0, top: 0, width: 4, height: 8 },
-                pixelRatio: 0.5,
             });
 
             await viewport.extendBy(2, newImage);
 
-            assert.calledWith(newImage.crop, { left: 0, top: 3, width: 2, height: 1 });
+            assert.calledWith(newImage.crop, { left: 0, top: 2, width: 2, height: 2 });
         });
 
         it("should join original image with cropped image", async () => {


### PR DESCRIPTION
### Что сделано?

Реализовал поддержку девайсов с дробным `pixelRatio`. Основная проблема была с `getBoundingClientRect`, который при дробном `pixelRatio` может вернуть ширину например со значением - `393.0909118652344`. А дальше мы это значение всегда `ceil`-им, чтобы отображать целый пиксель. Но обычно и `clientWidth` был равен этому округленному значению. А с дробными `pixelRatio` может быть такое, что `clientWidth = 393`, а от `getBoundingClientRect` `width = 394` (т.е. после округления). В итоге снимаемая область вываливалась за размер вьюпорта и кидали ошибку.

Теперь такой проблемы не будет.