### PR TITLE
fix: reset cursor correctly for body with negative coords

### DIFF
--- a/src/worker/runner/test-runner/index.js
+++ b/src/worker/runner/test-runner/index.js
@@ -116,7 +116,9 @@ module.exports = class TestRunner {
         }
 
         await body.scrollIntoView();
-        await body.moveTo({ xOffset: 0, yOffset: 0 });
+
+        const { x, y } = await body.getLocation();
+        await body.moveTo({ xOffset: -x, yOffset: -y });
     }
 };
 

--- a/test/src/worker/runner/test-runner/index.js
+++ b/test/src/worker/runner/test-runner/index.js
@@ -35,6 +35,7 @@ describe("worker/runner/test-runner", () => {
 
     const mkElement_ = proto => {
         return _.defaults(proto, {
+            getLocation: sandbox.stub().named("getLocation").resolves({ x: 0, y: 0 }),
             scrollIntoView: sandbox.stub().named("scrollIntoView").resolves(),
             moveTo: sandbox.stub().named("moveTo").resolves(),
         });
@@ -300,6 +301,14 @@ describe("worker/runner/test-runner", () => {
                     await run_();
 
                     assert.calledOnceWith(body.moveTo, { xOffset: 0, yOffset: 0 });
+                });
+
+                it("should move cursor correctly if body element has negative coords", async () => {
+                    body.getLocation.resolves({ x: -100, y: -500 });
+
+                    await run_();
+
+                    assert.calledOnceWith(body.moveTo, { xOffset: 100, yOffset: 500 });
                 });
 
                 it("should scroll before moving cursor", async () => {


### PR DESCRIPTION
**Что сделано**

* исправляю ошибку при сбросе курсора в нулевую позицию, которая возникает в том случае, если у `body` после подскролла оказываются отрицательные координаты