### PR TITLE
fix: reset cursor correctly for body with negative coords

### DIFF
--- a/.github/workflows/node.js.yml
+++ b/.github/workflows/node.js.yml
@@ -5,9 +5,9 @@ name: Node.js CI
 
 on:
   push:
-    branches: [ master ]
+    branches: [ master, hermione@6 ]
   pull_request:
-    branches: [ master ]
+    branches: [ master, hermione@6 ]
 
 jobs:
   build:

--- a/lib/worker/runner/test-runner/index.js
+++ b/lib/worker/runner/test-runner/index.js
@@ -96,7 +96,9 @@ module.exports = class TestRunner {
         }
 
         await body.scrollIntoView();
-        await body.moveTo({xOffset: 0, yOffset: 0});
+
+        const {x, y} = await body.getLocation();
+        await body.moveTo({xOffset: -x, yOffset: -y});
     }
 };
 

--- a/test/lib/worker/runner/test-runner/index.js
+++ b/test/lib/worker/runner/test-runner/index.js
@@ -30,6 +30,7 @@ describe('worker/runner/test-runner', () => {
 
     const mkElement_ = (proto) => {
         return _.defaults(proto, {
+            getLocation: sandbox.stub().named('getLocation').resolves({x: 0, y: 0}),
             scrollIntoView: sandbox.stub().named('scrollIntoView').resolves(),
             moveTo: sandbox.stub().named('moveTo').resolves()
         });
@@ -280,6 +281,14 @@ describe('worker/runner/test-runner', () => {
                     await run_();
 
                     assert.calledOnceWith(body.moveTo, {xOffset: 0, yOffset: 0});
+                });
+
+                it('should move cursor correctly if body element has negative coords', async () => {
+                    body.getLocation.resolves({x: -100, y: -500});
+
+                    await run_();
+
+                    assert.calledOnceWith(body.moveTo, {xOffset: 100, yOffset: 500});
                 });
 
                 it('should scroll before moving cursor', async () => {


### PR DESCRIPTION
**Что сделано**

* исправляю ошибку при сбросе курсора в нулевую позицию, которая возникает в том случае, если у `body` после подскролла оказываются отрицательные координаты
* поправил gh-actions, чтобы проверки запускались для ветки hermione@6