### PR TITLE
fix: add "type" field for runnable

### DIFF
--- a/src/test-reader/test-object/hook.js
+++ b/src/test-reader/test-object/hook.js
@@ -25,6 +25,10 @@ class Hook extends TestObject {
     get browserId() {
         return this.parent.browserId;
     }
+
+    get type() {
+        return "hook";
+    }
 }
 
 module.exports = {

--- a/src/test-reader/test-object/test.js
+++ b/src/test-reader/test-object/test.js
@@ -15,6 +15,10 @@ class Test extends ConfigurableTestObject {
             fn: this.fn,
         }).assign(this);
     }
+
+    get type() {
+        return "test";
+    }
 }
 
 module.exports = {

--- a/test/src/test-reader/test-object/hook.js
+++ b/test/src/test-reader/test-object/hook.js
@@ -115,4 +115,12 @@ describe("test-reader/test-object/hook", () => {
             assert.equal(hook.browserId, "foo");
         });
     });
+
+    describe("type", () => {
+        it("should return type name", () => {
+            const hook = new Hook({});
+
+            assert.equal(hook.type, "hook");
+        });
+    });
 });

--- a/test/src/test-reader/test-object/test.js
+++ b/test/src/test-reader/test-object/test.js
@@ -78,4 +78,12 @@ describe("test-reader/test-object/test", () => {
             assert.calledOn(Test.prototype.assign, clonedTest);
         });
     });
+
+    describe("type", () => {
+        it("should return type name", () => {
+            const test = new Test({});
+
+            assert.equal(test.type, "test");
+        });
+    });
 });


### PR DESCRIPTION
### Что сделано

Добавил свойство `type` в runnable (`test` и `hook`). Такое же поле есть в mocha:
- в test - https://github.com/mochajs/mocha/blob/master/lib/test.js#L31
- в hook - https://github.com/mochajs/mocha/blob/master/lib/hook.js#L23

Используется в некоторых плагинах, чтобы понять в контексте какого runnable была запущена кастомная команда. Проверка выглядит следующим образом:
```
ctx.type === "hook" && /^"(before|after) each"/.test(ctx.title) 
  ? console.log('it is hook')
  : console.log('it is test');
```

Проверить только название `before each` или `after each` недостаточно, так как пользователь может так же само назвать свой `it`. Ну и на самом деле `ctx.title` конечно можно не проверять, так как у нас доступны только `beforeEach` и `afterEach` хуки.