### PR TITLE
fix: handle unhandled rejections with circular refs on timeout error

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -33,6 +33,7 @@
         "mocha": "^10.2.0",
         "plugins-loader": "^1.1.0",
         "png-validator": "1.1.0",
+        "serialize-error": "^8.1.0",
         "sharp": "~0.30.7",
         "sizzle": "^2.3.6",
         "temp": "^0.8.3",

--- a/package.json
+++ b/package.json
@@ -67,6 +67,7 @@
     "mocha": "^10.2.0",
     "plugins-loader": "^1.1.0",
     "png-validator": "1.1.0",
+    "serialize-error": "^8.1.0",
     "sharp": "~0.30.7",
     "sizzle": "^2.3.6",
     "temp": "^0.8.3",


### PR DESCRIPTION
### Проблема

Внутри wdio используется got для http запросов. При выполнении запросов через got wdio устанавливает http и https агенты и таймаут на запрос. В итоге в случае если за отведенный таймаут запрос не был выполнен, то got кидает ошибку в которой содержатся циклические ссылки из-за использования своих агентов. После чего из worker-а пытаемся прокинуть ошибку в мастер с помощью `process.send` и под капотом выполняется `JSON.stringify` и в итоге получаем `Unhandled rejection` так как обработки ошибки не хватило.

### Решение

Использовать библиотеку `serialize-error` с помощью которой можно удалить циклические ссылки.