### PR TITLE
feat: add "headless" setting for the main 3 browsers

### DIFF
--- a/src/browser/browser.js
+++ b/src/browser/browser.js
@@ -16,7 +16,6 @@ const CUSTOM_SESSION_OPTS = [
     "user",
     "key",
     "region",
-    "headless",
 ];
 
 module.exports = class Browser {

--- a/src/browser/new-browser.js
+++ b/src/browser/new-browser.js
@@ -110,17 +110,29 @@ module.exports = class NewBrowser extends Browser {
             return capabilities;
         }
         if (capabilities.browserName === "chrome") {
-            capabilities["goog:chromeOptions"] = [
-                ...(capabilities["goog:chromeOptions"] ?? []),
-                "headless",
-                "disable-gpu",
-            ];
+            const googleCapabilities = capabilities["goog:chromeOptions"] ?? {};
+            capabilities["goog:chromeOptions"] = {
+                ...googleCapabilities,
+                args: [...(googleCapabilities.args ?? []), "headless", "disable-gpu"],
+            };
+            return capabilities;
         }
         if (capabilities.browserName === "firefox") {
-            capabilities["moz:firefoxOptions"] = [...(capabilities["moz:firefoxOptions"] ?? []), "-headless"];
+            const firefoxCapabilities = capabilities["moz:firefoxOptions"] ?? {};
+            capabilities["moz:firefoxOptions"] = {
+                ...firefoxCapabilities,
+                args: [...(firefoxCapabilities.args ?? []), "-headless"],
+            };
+            return capabilities;
         }
-        if (capabilities.browserName === "msedge") {
-            capabilities["ms:edgeOptions"] = [...(capabilities["ms:edgeOptions"] ?? []), "--headless"];
+        if (capabilities.browserName === "msedge" || capabilities.browserName === "edge") {
+            const edgeCapabilities = capabilities["ms:edgeOptions"] ?? {};
+
+            capabilities["ms:edgeOptions"] = {
+                ...edgeCapabilities,
+                args: [...(edgeCapabilities.args ?? []), "--headless"],
+            };
+            return capabilities;
         }
         return capabilities;
     }

--- a/src/browser/new-browser.js
+++ b/src/browser/new-browser.js
@@ -134,6 +134,7 @@ module.exports = class NewBrowser extends Browser {
             };
             return capabilities;
         }
+        logger.warn(`Headless setting is not supported for ${capabilities.browserName} browserName`);
         return capabilities;
     }
 

--- a/src/browser/new-browser.js
+++ b/src/browser/new-browser.js
@@ -72,7 +72,7 @@ module.exports = class NewBrowser extends Browser {
     _getSessionOpts() {
         const config = this._config;
         const gridUri = new URI(config.gridUrl);
-        const capabilities = this.version ? this._extendCapabilitiesByVersion() : config.desiredCapabilities;
+        const capabilities = this._extendCapabilities(config);
 
         const options = {
             protocol: gridUri.protocol(),
@@ -92,6 +92,37 @@ module.exports = class NewBrowser extends Browser {
         };
 
         return options;
+    }
+
+    _extendCapabilities(config) {
+        const capabilitiesExtendedByVersion = this.version
+            ? this._extendCapabilitiesByVersion()
+            : config.desiredCapabilities;
+        const capabilitiesWithAddedHeadless = this._addHeadlessCapability(
+            config.headless,
+            capabilitiesExtendedByVersion,
+        );
+        return capabilitiesWithAddedHeadless;
+    }
+
+    _addHeadlessCapability(headless, capabilities) {
+        if (!headless) {
+            return capabilities;
+        }
+        if (capabilities.browserName === "chrome") {
+            capabilities["goog:chromeOptions"] = [
+                ...(capabilities["goog:chromeOptions"] ?? []),
+                "headless",
+                "disable-gpu",
+            ];
+        }
+        if (capabilities.browserName === "firefox") {
+            capabilities["moz:firefoxOptions"] = [...(capabilities["goog:chromeOptions"] ?? []), "-headless"];
+        }
+        if (capabilities.browserName === "msedge") {
+            capabilities["ms:edgeOptions"] = [...(capabilities["goog:chromeOptions"] ?? []), "--headless"];
+        }
+        return capabilities;
     }
 
     _extendCapabilitiesByVersion() {

--- a/src/browser/new-browser.js
+++ b/src/browser/new-browser.js
@@ -134,7 +134,7 @@ module.exports = class NewBrowser extends Browser {
             };
             return capabilities;
         }
-        logger.warn(`Headless setting is not supported for ${capabilities.browserName} browserName`);
+        logger.warn(`WARNING: Headless setting is not supported for ${capabilities.browserName} browserName`);
         return capabilities;
     }
 

--- a/src/browser/new-browser.js
+++ b/src/browser/new-browser.js
@@ -11,6 +11,25 @@ const logger = require("../utils/logger");
 
 const DEFAULT_PORT = 4444;
 
+const headlessBrowserOptions = {
+    chrome: {
+        capabilityName: "goog:chromeOptions",
+        args: ["headless", "disable-gpu"],
+    },
+    firefox: {
+        capabilityName: "moz:firefoxOptions",
+        args: ["-headless"],
+    },
+    msedge: {
+        capabilityName: "ms:edgeOptions",
+        args: ["--headless"],
+    },
+    edge: {
+        capabilityName: "ms:edgeOptions",
+        args: ["--headless"],
+    },
+};
+
 module.exports = class NewBrowser extends Browser {
     constructor(config, id, version) {
         super(config, id, version);
@@ -109,32 +128,16 @@ module.exports = class NewBrowser extends Browser {
         if (!headless) {
             return capabilities;
         }
-        if (capabilities.browserName === "chrome") {
-            const googleCapabilities = capabilities["goog:chromeOptions"] ?? {};
-            capabilities["goog:chromeOptions"] = {
-                ...googleCapabilities,
-                args: [...(googleCapabilities.args ?? []), "headless", "disable-gpu"],
-            };
+        const capabilitySettings = headlessBrowserOptions[capabilities.browserName];
+        if (!capabilitySettings) {
+            logger.warn(`WARNING: Headless setting is not supported for ${capabilities.browserName} browserName`);
             return capabilities;
         }
-        if (capabilities.browserName === "firefox") {
-            const firefoxCapabilities = capabilities["moz:firefoxOptions"] ?? {};
-            capabilities["moz:firefoxOptions"] = {
-                ...firefoxCapabilities,
-                args: [...(firefoxCapabilities.args ?? []), "-headless"],
-            };
-            return capabilities;
-        }
-        if (capabilities.browserName === "msedge" || capabilities.browserName === "edge") {
-            const edgeCapabilities = capabilities["ms:edgeOptions"] ?? {};
-
-            capabilities["ms:edgeOptions"] = {
-                ...edgeCapabilities,
-                args: [...(edgeCapabilities.args ?? []), "--headless"],
-            };
-            return capabilities;
-        }
-        logger.warn(`WARNING: Headless setting is not supported for ${capabilities.browserName} browserName`);
+        const browserCapabilities = capabilities[capabilitySettings.capabilityName] ?? {};
+        capabilities[capabilitySettings.capabilityName] = {
+            ...browserCapabilities,
+            args: [...(browserCapabilities.args ?? []), ...capabilitySettings.args],
+        };
         return capabilities;
     }
 

--- a/src/browser/new-browser.js
+++ b/src/browser/new-browser.js
@@ -117,10 +117,10 @@ module.exports = class NewBrowser extends Browser {
             ];
         }
         if (capabilities.browserName === "firefox") {
-            capabilities["moz:firefoxOptions"] = [...(capabilities["goog:chromeOptions"] ?? []), "-headless"];
+            capabilities["moz:firefoxOptions"] = [...(capabilities["moz:firefoxOptions"] ?? []), "-headless"];
         }
         if (capabilities.browserName === "msedge") {
-            capabilities["ms:edgeOptions"] = [...(capabilities["goog:chromeOptions"] ?? []), "--headless"];
+            capabilities["ms:edgeOptions"] = [...(capabilities["ms:edgeOptions"] ?? []), "--headless"];
         }
         return capabilities;
     }

--- a/test/src/browser/new-browser.js
+++ b/test/src/browser/new-browser.js
@@ -56,7 +56,7 @@ describe("NewBrowser", () => {
                 assert.calledWithMatch(webdriverio.remote, {
                     capabilities: {
                         browserName: "chrome",
-                        "goog:chromeOptions": ["headless", "disable-gpu"],
+                        "goog:chromeOptions": { args: ["headless", "disable-gpu"] },
                         version: "1.0",
                     },
                 });
@@ -69,7 +69,11 @@ describe("NewBrowser", () => {
                 }).init();
 
                 assert.calledWithMatch(webdriverio.remote, {
-                    capabilities: { browserName: "firefox", "moz:firefoxOptions": ["-headless"], version: "1.0" },
+                    capabilities: {
+                        browserName: "firefox",
+                        "moz:firefoxOptions": { args: ["-headless"] },
+                        version: "1.0",
+                    },
                 });
             });
 
@@ -80,7 +84,7 @@ describe("NewBrowser", () => {
                 }).init();
 
                 assert.calledWithMatch(webdriverio.remote, {
-                    capabilities: { browserName: "msedge", "ms:edgeOptions": ["--headless"], version: "1.0" },
+                    capabilities: { browserName: "msedge", "ms:edgeOptions": { args: ["--headless"] }, version: "1.0" },
                 });
             });
 
@@ -90,14 +94,14 @@ describe("NewBrowser", () => {
                     desiredCapabilities: {
                         browserName: "chrome",
                         version: "1.0",
-                        "goog:chromeOptions": ["my", "custom", "flags"],
+                        "goog:chromeOptions": { args: ["my", "custom", "flags"] },
                     },
                 }).init();
 
                 assert.calledWithMatch(webdriverio.remote, {
                     capabilities: {
                         browserName: "chrome",
-                        "goog:chromeOptions": ["my", "custom", "flags", "headless", "disable-gpu"],
+                        "goog:chromeOptions": { args: ["my", "custom", "flags", "headless", "disable-gpu"] },
                         version: "1.0",
                     },
                 });

--- a/test/src/browser/new-browser.js
+++ b/test/src/browser/new-browser.js
@@ -46,18 +46,17 @@ describe("NewBrowser", () => {
             assert.calledWithMatch(webdriverio.remote, { port: 4444 });
         });
 
-        describe('should set "headless" setting in desiredCapabilities - chrome', () => {
+        describe('should set "headless" setting in capabilities', () => {
             it("in chrome", async () => {
                 await mkBrowser_({
                     headless: true,
-                    desiredCapabilities: { browserName: "chrome", version: "1.0" },
+                    desiredCapabilities: { browserName: "chrome" },
                 }).init();
 
                 assert.calledWithMatch(webdriverio.remote, {
                     capabilities: {
                         browserName: "chrome",
                         "goog:chromeOptions": { args: ["headless", "disable-gpu"] },
-                        version: "1.0",
                     },
                 });
             });
@@ -65,14 +64,13 @@ describe("NewBrowser", () => {
             it("in firefox", async () => {
                 await mkBrowser_({
                     headless: true,
-                    desiredCapabilities: { browserName: "firefox", version: "1.0" },
+                    desiredCapabilities: { browserName: "firefox" },
                 }).init();
 
                 assert.calledWithMatch(webdriverio.remote, {
                     capabilities: {
                         browserName: "firefox",
                         "moz:firefoxOptions": { args: ["-headless"] },
-                        version: "1.0",
                     },
                 });
             });
@@ -80,20 +78,19 @@ describe("NewBrowser", () => {
             it("in edge", async () => {
                 await mkBrowser_({
                     headless: true,
-                    desiredCapabilities: { browserName: "msedge", version: "1.0" },
+                    desiredCapabilities: { browserName: "msedge" },
                 }).init();
 
                 assert.calledWithMatch(webdriverio.remote, {
-                    capabilities: { browserName: "msedge", "ms:edgeOptions": { args: ["--headless"] }, version: "1.0" },
+                    capabilities: { browserName: "msedge", "ms:edgeOptions": { args: ["--headless"] } },
                 });
             });
 
-            it("when chromeOptions already specified", async () => {
+            it("in chrome when chromeOptions already specified", async () => {
                 await mkBrowser_({
                     headless: true,
                     desiredCapabilities: {
                         browserName: "chrome",
-                        version: "1.0",
                         "goog:chromeOptions": { args: ["my", "custom", "flags"] },
                     },
                 }).init();
@@ -102,7 +99,6 @@ describe("NewBrowser", () => {
                     capabilities: {
                         browserName: "chrome",
                         "goog:chromeOptions": { args: ["my", "custom", "flags", "headless", "disable-gpu"] },
-                        version: "1.0",
                     },
                 });
             });

--- a/test/src/browser/new-browser.js
+++ b/test/src/browser/new-browser.js
@@ -46,8 +46,8 @@ describe("NewBrowser", () => {
             assert.calledWithMatch(webdriverio.remote, { port: 4444 });
         });
 
-        describe('should set "headless" setting in capabilities', () => {
-            it("in chrome", async () => {
+        describe("headless setting", () => {
+            it("should generate browser specific settings - chrome", async () => {
                 await mkBrowser_({
                     headless: true,
                     desiredCapabilities: { browserName: "chrome" },
@@ -61,7 +61,7 @@ describe("NewBrowser", () => {
                 });
             });
 
-            it("in firefox", async () => {
+            it("should generate browser specific settings - firefox", async () => {
                 await mkBrowser_({
                     headless: true,
                     desiredCapabilities: { browserName: "firefox" },
@@ -75,7 +75,7 @@ describe("NewBrowser", () => {
                 });
             });
 
-            it("in edge", async () => {
+            it("should generate browser specific settings - edge", async () => {
                 await mkBrowser_({
                     headless: true,
                     desiredCapabilities: { browserName: "msedge" },
@@ -86,7 +86,7 @@ describe("NewBrowser", () => {
                 });
             });
 
-            it("in chrome when chromeOptions already specified", async () => {
+            it("not override existing settings", async () => {
                 await mkBrowser_({
                     headless: true,
                     desiredCapabilities: {
@@ -101,6 +101,15 @@ describe("NewBrowser", () => {
                         "goog:chromeOptions": { args: ["my", "custom", "flags", "headless", "disable-gpu"] },
                     },
                 });
+            });
+
+            it("should issue a warning for an unsupported browser", async () => {
+                await mkBrowser_({
+                    headless: true,
+                    desiredCapabilities: { browserName: "safari" },
+                }).init();
+
+                assert.calledOnceWith(logger.warn, "WARNING: Headless setting is not supported for safari browserName");
             });
         });
 

--- a/test/src/browser/new-browser.js
+++ b/test/src/browser/new-browser.js
@@ -46,6 +46,64 @@ describe("NewBrowser", () => {
             assert.calledWithMatch(webdriverio.remote, { port: 4444 });
         });
 
+        describe('should set "headless" setting in desiredCapabilities - chrome', () => {
+            it("in chrome", async () => {
+                await mkBrowser_({
+                    headless: true,
+                    desiredCapabilities: { browserName: "chrome", version: "1.0" },
+                }).init();
+
+                assert.calledWithMatch(webdriverio.remote, {
+                    capabilities: {
+                        browserName: "chrome",
+                        "goog:chromeOptions": ["headless", "disable-gpu"],
+                        version: "1.0",
+                    },
+                });
+            });
+
+            it("in firefox", async () => {
+                await mkBrowser_({
+                    headless: true,
+                    desiredCapabilities: { browserName: "firefox", version: "1.0" },
+                }).init();
+
+                assert.calledWithMatch(webdriverio.remote, {
+                    capabilities: { browserName: "firefox", "moz:firefoxOptions": ["-headless"], version: "1.0" },
+                });
+            });
+
+            it("in edge", async () => {
+                await mkBrowser_({
+                    headless: true,
+                    desiredCapabilities: { browserName: "msedge", version: "1.0" },
+                }).init();
+
+                assert.calledWithMatch(webdriverio.remote, {
+                    capabilities: { browserName: "msedge", "ms:edgeOptions": ["--headless"], version: "1.0" },
+                });
+            });
+
+            it("when chromeOptions already specified", async () => {
+                await mkBrowser_({
+                    headless: true,
+                    desiredCapabilities: {
+                        browserName: "chrome",
+                        version: "1.0",
+                        "goog:chromeOptions": ["my", "custom", "flags"],
+                    },
+                }).init();
+
+                assert.calledWithMatch(webdriverio.remote, {
+                    capabilities: {
+                        browserName: "chrome",
+                        "goog:chromeOptions": ["my", "custom", "flags", "headless", "disable-gpu"],
+                        version: "1.0",
+                    },
+                });
+            });
+        });
+
         describe('should create session with extended "browserVersion" in desiredCapabilities if', () => {
             it("it is already exists in capabilities", async () => {
                 await mkBrowser_(

--- a/typings/index.d.ts
+++ b/typings/index.d.ts
@@ -454,6 +454,7 @@ declare namespace Hermione {
         headers: Record<string, string> | null;
 
         system: SystemConfig;
+        headless: boolean | null;
     }
 
     export interface CompareOptsConfig {


### PR DESCRIPTION
Флаги взяты отсюда: https://webdriver.io/docs/capabilities/#run-browser-headless

У меня есть пара вопросов:
- я не вижу в коде гермионы нигде упомянания конкретных браузеров. Я правильно понимаю, что `desiredCapabilities.browserName` (который по докам является User Agent, и по логике может быть arbitary) и есть идентификатор конкретного движка? 
Я вообще ожидал что где-то в коде будет список поддерживаемых браузеров, и я не буду хардкодить "chrome", "msedge" и тп. Может быть я что-то пропустил.
- почему в доках гермионы есть `headless` настройка уже 2 года, а по сути ее не было все это время?)
- как осуществлять е2е тестирование? не вижу чтобы у нас были е2е тесты в репо. Как мне удостоверится что оно реально работает, а не только в юнит тестах? CI у нас как-то сделан помимо юнит тестов в github actions?