### PR TITLE
fix: do not reinit cached browser session in worker

### DIFF
--- a/src/browser/browser.js
+++ b/src/browser/browser.js
@@ -102,10 +102,6 @@ module.exports = class Browser {
         return this.publicAPI.sessionId;
     }
 
-    set sessionId(id) {
-        this.publicAPI.sessionId = id;
-    }
-
     get config() {
         return this._config;
     }

--- a/src/browser/existing-browser.js
+++ b/src/browser/existing-browser.js
@@ -44,18 +44,9 @@ module.exports = class ExistingBrowser extends Browser {
                 logger.warn(`WARN: couldn't prepare browser ${this.id}\n`, e.stack);
             }
 
-            await this._prepareSession(sessionId);
+            await this._prepareSession();
             await this._performCalibration(calibrator);
             await this._buildClientScripts();
-        });
-
-        return this;
-    }
-
-    async reinit(sessionId, sessionOpts) {
-        await history.runGroup(this._callstackHistory, "hermione: reinit browser", async () => {
-            this._session.extendOptions(sessionOpts);
-            await this._prepareSession(sessionId);
         });
 
         return this;
@@ -68,7 +59,6 @@ module.exports = class ExistingBrowser extends Browser {
     }
 
     quit() {
-        this.sessionId = null;
         this._meta = this._initMeta();
         this._state = { isBroken: false };
     }
@@ -211,8 +201,7 @@ module.exports = class ExistingBrowser extends Browser {
         return this._config.baseUrl ? url.resolve(this._config.baseUrl, uri) : uri;
     }
 
-    async _prepareSession(sessionId) {
-        this._attach(sessionId);
+    async _prepareSession() {
         await this._setOrientation(this.config.orientation);
         await this._setWindowSize(this.config.windowSize);
     }
@@ -244,10 +233,6 @@ module.exports = class ExistingBrowser extends Browser {
         return clientBridge
             .build(this, { calibration: this._calibration })
             .then(clientBridge => (this._clientBridge = clientBridge));
-    }
-
-    _attach(sessionId) {
-        this.sessionId = sessionId;
     }
 
     _stubCommands() {

--- a/src/worker/runner/browser-pool.js
+++ b/src/worker/runner/browser-pool.js
@@ -1,11 +1,9 @@
 "use strict";
 
-const _ = require("lodash");
 const Browser = require("../../browser/existing-browser");
 const Calibrator = require("../../browser/calibrator");
 const { WorkerEvents } = require("../../events");
 const ipc = require("../../utils/ipc");
-const { DEVTOOLS_PROTOCOL } = require("../../constants/config");
 
 module.exports = class BrowserPool {
     static create(config, emitter) {
@@ -15,32 +13,14 @@ module.exports = class BrowserPool {
     constructor(config, emitter) {
         this._config = config;
         this._emitter = emitter;
-        this._browsers = {};
         this._calibrator = new Calibrator();
     }
 
     async getBrowser({ browserId, browserVersion, sessionId, sessionCaps, sessionOpts }) {
-        const browserConfig = this._config.forBrowser(browserId);
-        this._browsers[browserId] = this._browsers[browserId] || [];
-
-        let browser = _.find(this._browsers[browserId], browser => {
-            return browserVersion
-                ? _.isNil(browser.sessionId) && browser.version === browserVersion
-                : _.isNil(browser.sessionId);
-        });
+        const browser = Browser.create(this._config, browserId, browserVersion, this._emitter);
 
         try {
-            if (browser) {
-                return await browser.reinit(sessionId, sessionOpts);
-            }
-
-            browser = Browser.create(this._config, browserId, browserVersion, this._emitter);
             await browser.init({ sessionId, sessionCaps, sessionOpts }, this._calibrator);
-
-            // TODO: use caching browser pool from master for webdriver and basic for devtools
-            if (browserConfig.automationProtocol !== DEVTOOLS_PROTOCOL) {
-                this._browsers[browserId].push(browser);
-            }
 
             this._emitter.emit(WorkerEvents.NEW_BROWSER, browser.publicAPI, { browserId: browser.id, browserVersion });
 
@@ -50,7 +30,6 @@ module.exports = class BrowserPool {
                 throw error;
             }
 
-            browser.sessionId = sessionId;
             browser.markAsBroken();
             this.freeBrowser(browser);
 
@@ -60,10 +39,6 @@ module.exports = class BrowserPool {
 
     freeBrowser(browser) {
         ipc.emit(`worker.${browser.sessionId}.freeBrowser`, browser.state);
-
-        if (browser.state.isBroken) {
-            _.pull(this._browsers[browser.id], browser);
-        }
 
         browser.quit();
     }

--- a/test/src/browser/existing-browser.js
+++ b/test/src/browser/existing-browser.js
@@ -408,12 +408,6 @@ describe("ExistingBrowser", () => {
             assert.calledOnce(logger.warn);
         });
 
-        it("should attach a browser to a provided session", async () => {
-            const browser = await initBrowser_(mkBrowser_(), { sessionId: "100-500" });
-
-            assert.equal(browser.sessionId, "100-500");
-        });
-
         describe("set browser orientation", () => {
             it("should not set orientation if it is not specified in a config", async () => {
                 await initBrowser_();
@@ -477,10 +471,10 @@ describe("ExistingBrowser", () => {
             it("should perform calibration after attaching of a session", async () => {
                 const browser = mkBrowser_({ calibrate: true });
 
-                await initBrowser_(browser, { sessionId: "100-500" }, calibrator);
+                await initBrowser_(browser, {}, calibrator);
 
                 const calibratorArg = calibrator.calibrate.lastCall.args[0];
-                assert.equal(calibratorArg.sessionId, "100-500");
+                assert.equal(calibratorArg, browser);
             });
         });
 
@@ -492,80 +486,6 @@ describe("ExistingBrowser", () => {
             await initBrowser_(browser, {}, calibrator);
 
             assert.calledOnceWith(clientBridge.build, browser, { calibration: { foo: "bar" } });
-        });
-    });
-
-    describe("reinit", () => {
-        it("should attach a browser to a provided session", async () => {
-            const browser = await initBrowser_();
-
-            await browser.reinit("100-500");
-
-            assert.equal(browser.sessionId, "100-500");
-        });
-
-        it("should redefine session options", async () => {
-            const browser = await initBrowser_(mkBrowser_(), { sessionOpts: { foo: "bar" } });
-
-            await browser.reinit("100-500", { bar: "foo" });
-
-            assert.deepEqual(browser.publicAPI.options, { bar: "foo" });
-        });
-
-        describe("set browser orientation", () => {
-            it("should not set orientation if it is not specified in a config", async () => {
-                const browser = await initBrowser_();
-
-                await browser.reinit();
-
-                assert.notCalled(session.setOrientation);
-            });
-
-            it("should set orientation again after init", async () => {
-                const browser = mkBrowser_({ orientation: "portrait" });
-                await initBrowser_(browser);
-
-                await browser.reinit();
-
-                assert.calledTwice(session.setOrientation);
-            });
-
-            it("should set orientation on reinit with specified value from config", async () => {
-                const browser = mkBrowser_({ orientation: "portrait" });
-                await initBrowser_(browser);
-
-                await browser.reinit();
-
-                assert.calledWith(session.setOrientation.secondCall, "portrait");
-            });
-        });
-
-        describe("set winidow size", () => {
-            it("should not set window size if it is not specified in a config", async () => {
-                const browser = await initBrowser_();
-
-                await browser.reinit();
-
-                assert.notCalled(session.setWindowSize);
-            });
-
-            it("should set window size again after init", async () => {
-                const browser = mkBrowser_({ windowSize: { width: 100500, height: 500100 } });
-                await initBrowser_(browser);
-
-                await browser.reinit();
-
-                assert.calledTwice(session.setWindowSize);
-            });
-
-            it("should set window size on reinit with specified values from config", async () => {
-                const browser = mkBrowser_({ windowSize: { width: 100500, height: 500100 } });
-                await initBrowser_(browser);
-
-                await browser.reinit();
-
-                assert.calledWith(session.setWindowSize.secondCall, 100500, 500100);
-            });
         });
     });
 

--- a/test/src/browser/new-browser.js
+++ b/test/src/browser/new-browser.js
@@ -312,15 +312,6 @@ describe("NewBrowser", () => {
 
             assert.equal(browser.sessionId, "foo");
         });
-
-        it("should set session id", async () => {
-            session.sessionId = "foo";
-            const browser = await mkBrowser_().init();
-
-            browser.sessionId = "bar";
-
-            assert.equal(browser.sessionId, "bar");
-        });
     });
 
     describe("error handling", () => {

--- a/test/src/worker/runner/browser-pool.js
+++ b/test/src/worker/runner/browser-pool.js
@@ -8,7 +8,6 @@ const Calibrator = require("src/browser/calibrator");
 const { WorkerEvents: RunnerEvents } = require("src/events");
 const logger = require("src/utils/logger");
 const ipc = require("src/utils/ipc");
-const { WEBDRIVER_PROTOCOL, DEVTOOLS_PROTOCOL } = require("src/constants/config");
 
 describe("worker/browser-pool", () => {
     const sandbox = sinon.sandbox.create();
@@ -34,7 +33,6 @@ describe("worker/browser-pool", () => {
         });
 
         bro.init = sandbox.stub().resolves();
-        bro.reinit = sandbox.stub().resolves(bro);
         bro.quit = sandbox.stub();
         bro.markAsBroken = sandbox.stub();
 
@@ -49,422 +47,162 @@ describe("worker/browser-pool", () => {
 
     afterEach(() => sandbox.restore());
 
-    [WEBDRIVER_PROTOCOL, DEVTOOLS_PROTOCOL].forEach(automationProtocol => {
-        describe(`with using "${automationProtocol}" protocol`, () => {
-            let config;
+    describe("getBrowser", () => {
+        it("should create browser with correct args", async () => {
+            const config = stubConfig();
+            const emitter = new EventEmitter();
+            const browserPool = createPool({ config, emitter });
+            const browser = stubBrowser({ browserId: "bro-id" });
+            Browser.create.withArgs(config, "bro-id", undefined, emitter).returns(browser);
 
+            await browserPool.getBrowser({ browserId: "bro-id" });
+
+            assert.calledOnceWith(Browser.create, config, "bro-id", undefined, emitter);
+        });
+
+        it("should create specific version of browser with correct args", async () => {
+            const config = stubConfig();
+            const emitter = new EventEmitter();
+            const browserPool = createPool({ config, emitter });
+            const browser = stubBrowser({ browserId: "bro-id" });
+            Browser.create.withArgs(config, "bro-id", "10.1", emitter).returns(browser);
+
+            await browserPool.getBrowser({ browserId: "bro-id", browserVersion: "10.1" });
+
+            assert.calledOnceWith(Browser.create, config, "bro-id", "10.1", emitter);
+        });
+
+        it("should init a new created browser ", async () => {
+            const browser = stubBrowser({ browserId: "bro-id" });
+            Browser.create.returns(browser);
+
+            await createPool().getBrowser({
+                browserId: "bro-id",
+                sessionId: "100-500",
+                sessionCaps: "some-caps",
+                sessionOpts: "some-opts",
+            });
+
+            assert.calledOnceWith(
+                browser.init,
+                { sessionId: "100-500", sessionCaps: "some-caps", sessionOpts: "some-opts" },
+                sinon.match.instanceOf(Calibrator),
+            );
+        });
+
+        it('should emit "NEW_BROWSER" event on creating of a browser', async () => {
+            const emitter = new EventEmitter();
+            const onNewBrowser = sandbox.spy().named("onNewBrowser");
+            const browserPool = createPool({ emitter });
+
+            emitter.on(RunnerEvents.NEW_BROWSER, onNewBrowser);
+
+            Browser.create.returns(stubBrowser({ id: "bro-id", publicAPI: { some: "api" } }));
+
+            await browserPool.getBrowser({ browserId: "bro-id", browserVersion: "10.1" });
+
+            assert.calledOnceWith(onNewBrowser, { some: "api" }, { browserId: "bro-id", browserVersion: "10.1" });
+        });
+
+        it("should return a new created browser", () => {
+            const config = stubConfig();
+            const browserPool = createPool({ config });
+            const browser = stubBrowser({ browserId: "bro-id" });
+
+            Browser.create.withArgs(config, "bro-id").returns(browser);
+
+            return assert.becomes(browserPool.getBrowser({ browserId: "bro-id" }), browser);
+        });
+
+        it("should return a new createt browser with specific version", () => {
+            const config = stubConfig();
+            const browserPool = createPool({ config });
+            const browser = stubBrowser({ browserId: "bro-id" });
+
+            Browser.create.withArgs(config, "bro-id", "10.1").returns(browser);
+
+            return assert.becomes(browserPool.getBrowser({ browserId: "bro-id", browserVersion: "10.1" }), browser);
+        });
+
+        describe("getting of browser fails", () => {
             beforeEach(() => {
-                config = stubConfig({ automationProtocol });
+                sandbox.spy(BrowserPool.prototype, "freeBrowser");
             });
 
-            describe("getBrowser", () => {
-                it("should create browser with correct args", async () => {
-                    const emitter = new EventEmitter();
-                    const browserPool = createPool({ config, emitter });
-                    const browser = stubBrowser({ browserId: "bro-id" });
-                    Browser.create.withArgs(config, "bro-id", undefined, emitter).returns(browser);
+            it("should be rejected if instance of browser was not created", () => {
+                Browser.create.throws(new Error("foo bar"));
 
-                    await browserPool.getBrowser({ browserId: "bro-id" });
-
-                    assert.calledOnceWith(Browser.create, config, "bro-id", undefined, emitter);
-                });
-
-                it("should create specific version of browser with correct args", async () => {
-                    const emitter = new EventEmitter();
-                    const browserPool = createPool({ config, emitter });
-                    const browser = stubBrowser({ browserId: "bro-id" });
-                    Browser.create.withArgs(config, "bro-id", "10.1", emitter).returns(browser);
-
-                    await browserPool.getBrowser({ browserId: "bro-id", browserVersion: "10.1" });
-
-                    assert.calledOnceWith(Browser.create, config, "bro-id", "10.1", emitter);
-                });
-
-                it("should create a new browser if there are no free browsers in a cache", () => {
-                    const browserPool = createPool({ config });
-                    const browser = stubBrowser({ browserId: "bro-id" });
-
-                    Browser.create.withArgs(config, "bro-id").returns(browser);
-
-                    return assert.becomes(browserPool.getBrowser({ browserId: "bro-id" }), browser);
-                });
-
-                it("should create a new browser with specific version if there are no free browsers in a cache", () => {
-                    const browserPool = createPool({ config });
-                    const browser = stubBrowser({ browserId: "bro-id" });
-
-                    Browser.create.withArgs(config, "bro-id", "10.1").returns(browser);
-
-                    return assert.becomes(
-                        browserPool.getBrowser({ browserId: "bro-id", browserVersion: "10.1" }),
-                        browser,
-                    );
-                });
-
-                it("should init a new created browser if there are no free browsers in a cache", async () => {
-                    const browser = stubBrowser({ browserId: "bro-id" });
-
-                    Browser.create.returns(browser);
-
-                    await createPool({ config }).getBrowser({
-                        browserId: "bro-id",
-                        sessionId: "100-500",
-                        sessionCaps: "some-caps",
-                        sessionOpts: "some-opts",
-                    });
-
-                    assert.calledOnceWith(
-                        browser.init,
-                        { sessionId: "100-500", sessionCaps: "some-caps", sessionOpts: "some-opts" },
-                        sinon.match.instanceOf(Calibrator),
-                    );
-                });
-
-                it('should emit "NEW_BROWSER" event on creating of a browser', async () => {
-                    const emitter = new EventEmitter();
-                    const onNewBrowser = sandbox.spy().named("onNewBrowser");
-                    const browserPool = createPool({ config, emitter });
-
-                    emitter.on(RunnerEvents.NEW_BROWSER, onNewBrowser);
-
-                    Browser.create.returns(stubBrowser({ id: "bro-id", publicAPI: { some: "api" } }));
-
-                    await browserPool.getBrowser({ browserId: "bro-id", browserVersion: "10.1" });
-
-                    assert.calledOnceWith(
-                        onNewBrowser,
-                        { some: "api" },
-                        { browserId: "bro-id", browserVersion: "10.1" },
-                    );
-                });
-
-                describe("getting of browser fails", () => {
-                    beforeEach(() => {
-                        sandbox.spy(BrowserPool.prototype, "freeBrowser");
-                    });
-
-                    it("should be rejected if instance of browser was not created", () => {
-                        Browser.create.throws(new Error("foo bar"));
-
-                        return assert.isRejected(createPool({ config }).getBrowser({}), /foo bar/);
-                    });
-
-                    describe("init fails", () => {
-                        const stubBrowserWhichRejectsOnInit = (params = {}) => {
-                            const browser = stubBrowser(params);
-                            Browser.create.returns(browser);
-
-                            browser.init.rejects();
-
-                            return browser;
-                        };
-
-                        it("should mark browser as broken", async () => {
-                            const browser = stubBrowserWhichRejectsOnInit({ id: "bro-id" });
-
-                            await createPool({ config })
-                                .getBrowser({ browserId: "bro-id" })
-                                .catch(e => e);
-
-                            assert.calledOnceWith(browser.markAsBroken);
-                        });
-
-                        it("should extend browser with session id", async () => {
-                            const browser = stubBrowserWhichRejectsOnInit({ id: "bro-id" });
-
-                            await createPool({ config })
-                                .getBrowser({ browserId: "bro-id", sessionId: "100500" })
-                                .catch(e => e);
-
-                            assert.equal(browser.sessionId, "100500");
-                        });
-
-                        it("should extend browser with session id and browser version", async () => {
-                            const browser = stubBrowserWhichRejectsOnInit({ id: "bro-id", version: "10.1" });
-
-                            await createPool({ config })
-                                .getBrowser({ browserId: "bro-id", browserVersion: "10.1", sessionId: "100500" })
-                                .catch(e => e);
-
-                            assert.equal(browser.version, "10.1");
-                        });
-
-                        it("should free browser", async () => {
-                            const browser = stubBrowserWhichRejectsOnInit({ id: "bro-id" });
-
-                            await createPool({ config })
-                                .getBrowser({ browserId: "bro-id" })
-                                .catch(e => e);
-
-                            assert.calledOnceWith(BrowserPool.prototype.freeBrowser, browser);
-                        });
-
-                        it("should free browser after marking browser as broken", async () => {
-                            const browser = stubBrowserWhichRejectsOnInit({ id: "bro-id" });
-
-                            await createPool({ config })
-                                .getBrowser({ browserId: "bro-id" })
-                                .catch(e => e);
-
-                            assert.callOrder(browser.markAsBroken, BrowserPool.prototype.freeBrowser);
-                        });
-
-                        it("should be rejected with error extended by browser meta", async () => {
-                            stubBrowserWhichRejectsOnInit({ id: "bro-id", meta: { foo: "bar" } });
-
-                            const error = await createPool({ config })
-                                .getBrowser({ browserId: "bro-id" })
-                                .catch(e => e);
-
-                            assert.deepEqual(error.meta, { foo: "bar" });
-                        });
-                    });
-                });
+                return assert.isRejected(createPool().getBrowser({}), /foo bar/);
             });
 
-            describe("freeBrowser", () => {
-                it('should set session id to "null"', async () => {
-                    const browserPool = createPool({ config });
-
-                    Browser.create.returns(stubBrowser());
-
-                    const browser = await browserPool.getBrowser({ browserId: "bro-id" });
-                    browserPool.freeBrowser(browser);
-
-                    assert.calledOnce(browser.quit);
-                });
-
-                it("should send test related freeBrowser event on browser release", async () => {
-                    await createPool({ config }).freeBrowser(
-                        stubBrowser({ sessionId: "100500", state: { foo: "bar" } }),
-                    );
-
-                    assert.calledOnceWith(ipc.emit, "worker.100500.freeBrowser", { foo: "bar" });
-                });
-            });
-        });
-    });
-
-    describe(`with using "${WEBDRIVER_PROTOCOL}" protocol`, () => {
-        let config;
-
-        beforeEach(() => {
-            config = stubConfig({ automationProtocol: WEBDRIVER_PROTOCOL });
-        });
-
-        describe("getBrowser", () => {
-            it("should not create a new browser if there is a free browser in a cache", async () => {
-                const browserPool = createPool({ config });
-
-                Browser.create.returns(stubBrowser());
-
-                const browser = await browserPool.getBrowser({ browserId: "bro-id", sessionId: "100-500" });
-                browserPool.freeBrowser(browser);
-                Browser.create.resetHistory();
-
-                const anotherBrowser = await browserPool.getBrowser({ browserId: "bro-id", sessionsId: "500-100" });
-                assert.deepEqual(browser, anotherBrowser);
-                assert.notCalled(Browser.create);
-            });
-
-            it("should not create a new browser if there is a free browser in a cache with same version", async () => {
-                const browserPool = createPool({ config });
-                Browser.create.returns(stubBrowser({ version: "1.1" }));
-
-                const browser = await browserPool.getBrowser({
-                    browserId: "bro-id",
-                    browserVersion: "1.1",
-                    sessionId: "100-500",
-                });
-                browserPool.freeBrowser(browser);
-                Browser.create.resetHistory();
-
-                const anotherBrowser = await browserPool.getBrowser({
-                    browserId: "bro-id",
-                    browserVersion: "1.1",
-                    sessionId: "500-100",
-                });
-                assert.deepEqual(browser, anotherBrowser);
-                assert.notCalled(Browser.create);
-            });
-
-            it("should reinit a given session to a free browser in a cache", async () => {
-                const browserPool = createPool({ config });
-                Browser.create.returns(stubBrowser());
-
-                const browser = await browserPool.getBrowser({
-                    browserId: "bro-id",
-                    sessionId: "100-500",
-                    sessionOpts: { foo: "bar" },
-                });
-                browserPool.freeBrowser(browser);
-
-                const anotherBrowser = await browserPool.getBrowser({
-                    browserId: "bro-id",
-                    sessionId: "500-100",
-                    sessionOpts: { bar: "foo" },
-                });
-                assert.calledOnceWith(anotherBrowser.reinit, "500-100", { bar: "foo" });
-            });
-
-            it('should not emit "NEW_BROWSER" event on getting of a free browser from a cache', async () => {
-                const emitter = new EventEmitter();
-                const onNewBrowser = sandbox.spy().named("onNewBrowser");
-                const browserPool = createPool({ config, emitter });
-
-                Browser.create.returns(stubBrowser());
-
-                emitter.on(RunnerEvents.NEW_BROWSER, onNewBrowser);
-
-                const browser = await browserPool.getBrowser({ browserId: "bro-id" });
-                browserPool.freeBrowser(browser);
-
-                onNewBrowser.resetHistory();
-
-                await browserPool.getBrowser({ browserId: "bro-id" });
-                assert.notCalled(onNewBrowser);
-            });
-
-            describe("reinit fails", () => {
-                beforeEach(() => {
-                    sandbox.spy(BrowserPool.prototype, "freeBrowser");
-                });
-
-                const stubBrowserWhichRejectsOnReinit = (params = {}) => {
+            describe("init fails", () => {
+                const stubBrowserWhichRejectsOnInit = (params = {}) => {
                     const browser = stubBrowser(params);
                     Browser.create.returns(browser);
 
-                    browser.reinit.rejects();
+                    browser.init.rejects();
 
                     return browser;
                 };
 
                 it("should mark browser as broken", async () => {
-                    const browser = stubBrowserWhichRejectsOnReinit({ id: "bro-id" });
-                    const browserPool = createPool({ config });
+                    const browser = stubBrowserWhichRejectsOnInit({ id: "bro-id" });
 
-                    await browserPool.getBrowser({ browserId: "bro-id" });
-                    await browserPool.freeBrowser(browser);
-                    await browserPool.getBrowser({ browserId: "bro-id" }).catch(e => e);
+                    await createPool()
+                        .getBrowser({ browserId: "bro-id" })
+                        .catch(e => e);
 
-                    assert.calledOnce(browser.markAsBroken);
-                });
-
-                it("should extend browser with session id", async () => {
-                    const browser = stubBrowserWhichRejectsOnReinit({ id: "bro-id" });
-                    const browserPool = createPool({ config });
-
-                    await browserPool.getBrowser({ browserId: "bro-id" });
-                    await browserPool.freeBrowser(browser);
-                    await browserPool.getBrowser({ browserId: "bro-id", sessionId: "100500" }).catch(e => e);
-
-                    assert.equal(browser.sessionId, "100500");
+                    assert.calledOnceWith(browser.markAsBroken);
                 });
 
                 it("should free browser", async () => {
-                    const browser = stubBrowserWhichRejectsOnReinit({ id: "bro-id" });
-                    const browserPool = createPool({ config });
+                    const browser = stubBrowserWhichRejectsOnInit({ id: "bro-id" });
 
-                    await browserPool.getBrowser({ browserId: "bro-id" });
-                    await browserPool.freeBrowser(browser);
-                    browserPool.freeBrowser.resetHistory();
-                    await browserPool.getBrowser({ browserId: "bro-id" }).catch(e => e);
+                    await createPool()
+                        .getBrowser({ browserId: "bro-id" })
+                        .catch(e => e);
 
-                    assert.calledOnceWith(browserPool.freeBrowser, browser);
+                    assert.calledOnceWith(BrowserPool.prototype.freeBrowser, browser);
                 });
 
                 it("should free browser after marking browser as broken", async () => {
-                    const browser = stubBrowserWhichRejectsOnReinit({ id: "bro-id" });
-                    const browserPool = createPool({ config });
+                    const browser = stubBrowserWhichRejectsOnInit({ id: "bro-id" });
 
-                    await browserPool.getBrowser({ browserId: "bro-id" });
-                    await browserPool.freeBrowser(browser);
-                    browserPool.freeBrowser.resetHistory();
-                    await browserPool.getBrowser({ browserId: "bro-id" }).catch(e => e);
+                    await createPool()
+                        .getBrowser({ browserId: "bro-id" })
+                        .catch(e => e);
 
-                    assert.callOrder(browser.markAsBroken, browserPool.freeBrowser);
+                    assert.callOrder(browser.markAsBroken, BrowserPool.prototype.freeBrowser);
                 });
 
                 it("should be rejected with error extended by browser meta", async () => {
-                    const browser = stubBrowserWhichRejectsOnReinit({ id: "bro-id", meta: { foo: "bar" } });
-                    const browserPool = createPool({ config });
+                    stubBrowserWhichRejectsOnInit({ id: "bro-id", meta: { foo: "bar" } });
 
-                    await browserPool.getBrowser({ browserId: "bro-id" });
-                    await browserPool.freeBrowser(browser);
-                    const error = await browserPool.getBrowser({ browserId: "bro-id" }).catch(e => e);
+                    const error = await createPool()
+                        .getBrowser({ browserId: "bro-id" })
+                        .catch(e => e);
 
                     assert.deepEqual(error.meta, { foo: "bar" });
                 });
             });
         });
-
-        describe("freeBrowser", () => {
-            it("should create a new browser if there is a broken browser in a cache", async () => {
-                const browserPool = createPool({ config });
-
-                Browser.create.returns(stubBrowser({ id: "bro-id", state: { isBroken: true } }));
-
-                const browser = await browserPool.getBrowser({ browserId: "bro-id" });
-                browserPool.freeBrowser(browser);
-                Browser.create.resetHistory();
-
-                await browserPool.getBrowser({ browserId: "bro-id" });
-                assert.calledOnce(Browser.create);
-            });
-        });
     });
 
-    describe(`with using "${DEVTOOLS_PROTOCOL}" protocol`, () => {
-        let config;
+    describe("freeBrowser", () => {
+        it("should send test related freeBrowser event on browser release", async () => {
+            await createPool().freeBrowser(stubBrowser({ sessionId: "100500", state: { foo: "bar" } }));
 
-        beforeEach(() => {
-            config = stubConfig({ automationProtocol: DEVTOOLS_PROTOCOL });
+            assert.calledOnceWith(ipc.emit, "worker.100500.freeBrowser", { foo: "bar" });
         });
 
-        describe("getBrowser", () => {
-            it("should always create a new browser", async () => {
-                const browserPool = createPool({ config });
-                Browser.create
-                    .onFirstCall()
-                    .returns(stubBrowser({ foo: 1 }))
-                    .onSecondCall()
-                    .returns(stubBrowser({ foo: 2 }));
+        it("should quit from browser", async () => {
+            const browserPool = createPool();
+            Browser.create.returns(stubBrowser());
 
-                const browser = await browserPool.getBrowser({ browserId: "bro-id", sessionId: "100-500" });
-                browserPool.freeBrowser(browser);
+            const browser = await browserPool.getBrowser({ browserId: "bro-id" });
+            browserPool.freeBrowser(browser);
 
-                const anotherBrowser = await browserPool.getBrowser({ browserId: "bro-id", sessionsId: "500-100" });
-                assert.notEqual(browser, anotherBrowser);
-                assert.calledTwice(Browser.create);
-            });
-
-            it("should never reinit a given session", async () => {
-                const browserPool = createPool({ config });
-                Browser.create.returns(stubBrowser());
-
-                const browser = await browserPool.getBrowser({ browserId: "bro-id", sessionId: "100-500" });
-                browserPool.freeBrowser(browser);
-
-                const anotherBrowser = await browserPool.getBrowser({ browserId: "bro-id", sessionId: "500-100" });
-                assert.notCalled(anotherBrowser.reinit);
-            });
-
-            it('should always emit "NEW_BROWSER" event without using cache', async () => {
-                const emitter = new EventEmitter();
-                const onNewBrowser = sandbox.spy().named("onNewBrowser");
-                const browserPool = createPool({ config, emitter });
-
-                Browser.create.returns(stubBrowser());
-
-                emitter.on(RunnerEvents.NEW_BROWSER, onNewBrowser);
-
-                const browser = await browserPool.getBrowser({ browserId: "bro-id" });
-                browserPool.freeBrowser(browser);
-
-                await browserPool.getBrowser({ browserId: "bro-id" });
-
-                assert.calledTwice(onNewBrowser);
-            });
+            assert.calledOnce(browser.quit);
         });
     });
 });


### PR DESCRIPTION
### What is done?

Stop using cache of browsers sessions in worker. Causes:
- selenium/selenoid/... return `se:cdp` capability in response with `sessionId` on the end of the url and we don't modify it; 
- if use cdp protocol to quickly open browsers (in the near future), then we need reinitialize additional options in cached browsers;
- no big difference in execution speed, but a lot of problem with support in future.