### PR TITLE
fix: fix test id to be property and not a method in typings

### DIFF
--- a/typings/index.d.ts
+++ b/typings/index.d.ts
@@ -239,7 +239,7 @@ declare namespace Hermione {
     }
 
     export interface Suite extends Hermione.MochaSuite {
-        id(): string;
+        id: string;
         browserId: string;
         history: History;
     }
@@ -274,7 +274,7 @@ declare namespace Hermione {
     }
 
     export interface Test extends Hermione.MochaTest {
-        id(): string;
+        id: string;
         browserId: string;
         sessionId: string;
     }


### PR DESCRIPTION
Typings are out of sync as of now: in code, id is a property, however in types it's still a method. This PR addresses this issue.