### PR TITLE
fix: export TestResult and Suite types

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -8,7 +8,7 @@ import "expect-webdriverio";
 import { GlobalHelper } from "./types";
 export { Hermione as default } from "./hermione";
 
-export type { WdioBrowser } from "./types";
+export type { WdioBrowser, TestResult, Suite } from "./types";
 export type { Config } from "./config";
 export type { ConfigInput } from "./config/types";
 


### PR DESCRIPTION
### What's done?
- Added exports of `TestResult` and `Suite` types
- Impoved `AssertViewResult` types

### Why?
- These types are needed in https://github.com/gemini-testing/html-reporter/pull/493