### PR TITLE
fix: correctly disable animations in iframes for ios

### DIFF
--- a/src/browser/existing-browser.js
+++ b/src/browser/existing-browser.js
@@ -307,7 +307,10 @@ module.exports = class ExistingBrowser extends Browser {
                 await cb();
             }
         } finally {
-            await this._session.switchToParentFrame();
+            if (!_.isEmpty(iframes)) {
+                // switchToParentFrame does not work in ios - https://github.com/appium/appium/issues/14882
+                await this._session.switchToFrame(null);
+            }
         }
     }
 

--- a/test/src/browser/existing-browser.js
+++ b/test/src/browser/existing-browser.js
@@ -731,7 +731,8 @@ describe("ExistingBrowser", () => {
         it("should disable animations if 'disableAnimation: true' and 'automationProtocol: webdriver'", async () => {
             const clientBridge = stubClientBridge_();
             const browser = await initBrowser_(mkBrowser_({ automationProtocol: "webdriver" }));
-            const [wdElement] = await browser.publicAPI.findElements("css selector", ".some-selector");
+            const iframeElement = { "element-12345": "67890_element_1" };
+            browser.publicAPI.findElements.withArgs("css selector", "iframe").resolves([iframeElement]);
 
             await browser.prepareScreenshot(".selector", { disableAnimation: true });
 
@@ -739,7 +740,7 @@ describe("ExistingBrowser", () => {
                 ".selector",
                 sinon.match({ disableAnimation: true }),
             ]);
-            assert.calledOnceWith(browser.publicAPI.switchToFrame, wdElement);
+            assert.calledWith(browser.publicAPI.switchToFrame, iframeElement);
             assert.calledWith(clientBridge.call, "disableFrameAnimations");
         });
 
@@ -760,7 +761,8 @@ describe("ExistingBrowser", () => {
         it("should not disable animations if 'disableAnimation: false'", async () => {
             const clientBridge = stubClientBridge_();
             const browser = await initBrowser_(mkBrowser_({ automationProtocol: "webdriver" }));
-            const [wdElement] = await browser.publicAPI.findElements("css selector", ".some-selector");
+            const iframeElement = { "element-12345": "67890_element_1" };
+            browser.publicAPI.findElements.withArgs("css selector", "iframe").resolves([iframeElement]);
 
             await browser.prepareScreenshot(".selector", { disableAnimation: false });
 
@@ -768,7 +770,7 @@ describe("ExistingBrowser", () => {
                 ".selector",
                 sinon.match({ disableAnimation: true }),
             ]);
-            assert.neverCalledWith(browser.publicAPI.switchToFrame, wdElement);
+            assert.neverCalledWith(browser.publicAPI.switchToFrame, iframeElement);
             assert.neverCalledWith(clientBridge.call, "disableFrameAnimations");
         });
     });
@@ -792,27 +794,52 @@ describe("ExistingBrowser", () => {
             assert.neverCalledWith(clientBridge.call, "cleanupFrameAnimations");
         });
 
-        it("should cleanup animations in iframe if 'automationProtocol: webdriver'", async () => {
-            const clientBridge = stubClientBridge_();
-            const browser = await initBrowser_(mkBrowser_({ automationProtocol: "webdriver" }));
-            const [wdElement] = await browser.publicAPI.findElements("css selector", ".some-selector");
-
-            await browser.cleanupScreenshot({ disableAnimation: true });
-
-            assert.calledOnceWith(browser.publicAPI.switchToFrame, wdElement);
-            assert.calledWith(clientBridge.call, "cleanupFrameAnimations");
-            assert.callOrder(browser.publicAPI.switchToFrame, clientBridge.call);
-        });
-
         it("should not cleanup animations in iframe if 'automationProtocol: devtools'", async () => {
-            const clientBridge = stubClientBridge_();
+            stubClientBridge_();
             const browser = await initBrowser_(mkBrowser_({ automationProtocol: "devtools" }));
-            const [wdElement] = await browser.publicAPI.findElements("css selector", ".some-selector");
 
             await browser.cleanupScreenshot({ disableAnimation: true });
 
             assert.notCalled(browser.publicAPI.switchToFrame);
-            assert.neverCalledWith(clientBridge.call, "cleanupFrameAnimations", wdElement);
+        });
+
+        describe("'automationProtocol: webdriver'", () => {
+            it("should cleanup animations in iframe", async () => {
+                const clientBridge = stubClientBridge_();
+                const browser = await initBrowser_(mkBrowser_({ automationProtocol: "webdriver" }));
+                const iframeElement = { "element-12345": "67890_element_1" };
+                browser.publicAPI.findElements.withArgs("css selector", "iframe").resolves([iframeElement]);
+
+                await browser.cleanupScreenshot({ disableAnimation: true });
+
+                assert.calledWith(browser.publicAPI.switchToFrame, iframeElement);
+                assert.calledWith(clientBridge.call, "cleanupFrameAnimations");
+                assert.callOrder(browser.publicAPI.switchToFrame, clientBridge.call);
+            });
+
+            it("should switch to parent frame after clean animations in iframe", async () => {
+                stubClientBridge_();
+                const browser = await initBrowser_(mkBrowser_({ automationProtocol: "webdriver" }));
+                const iframeElement = { "element-12345": "67890_element_1" };
+                browser.publicAPI.findElements.withArgs("css selector", "iframe").resolves([iframeElement]);
+
+                await browser.cleanupScreenshot({ disableAnimation: true });
+
+                assert.callOrder(
+                    browser.publicAPI.switchToFrame.withArgs(iframeElement),
+                    browser.publicAPI.switchToFrame.withArgs(null),
+                );
+            });
+
+            it("should not switch to any frame if there are no iframes on the page ", async () => {
+                stubClientBridge_();
+                const browser = await initBrowser_(mkBrowser_({ automationProtocol: "webdriver" }));
+                browser.publicAPI.findElements.withArgs("css selector", "iframe").resolves([]);
+
+                await browser.cleanupScreenshot({ disableAnimation: true });
+
+                assert.notCalled(browser.publicAPI.switchToFrame);
+            });
         });
     });
 

--- a/test/src/browser/utils.js
+++ b/test/src/browser/utils.js
@@ -74,9 +74,6 @@ exports.mkSessionStub_ = () => {
         click: sinon.stub().named("click").resolves(),
         waitForExist: sinon.stub().named("waitForExist").resolves(),
     };
-    const wdElement = {
-        "element-6066-11e4-a52e-4f735466cecf": "95777D6590AF653A2FD8EB0ADD20B333_element_1",
-    };
 
     session.sessionId = "1234567890";
     session.isW3C = false;
@@ -101,9 +98,8 @@ exports.mkSessionStub_ = () => {
     session.mock = sinon.stub().named("mock").resolves(exports.mkMockStub_());
     session.getWindowHandles = sinon.stub().named("getWindowHandles").resolves([]);
     session.switchToWindow = sinon.stub().named("switchToWindow").resolves();
-    session.findElements = sinon.stub().named("findElements").resolves([wdElement]);
+    session.findElements = sinon.stub().named("findElements").resolves([]);
     session.switchToFrame = sinon.stub().named("switchToFrame").resolves();
-    session.switchToParentFrame = sinon.stub().named("switchToParentFrame").resolves();
 
     session.addCommand = sinon.stub().callsFake((name, command, isElement) => {
         const target = isElement ? wdioElement : session;


### PR DESCRIPTION
### What is done

Method `switchToParentFrame` is not supported in ios, so I used `switchToFrame(null)` which does the same thing.