### PR TITLE
fix: log full error object if default toString is not enough

### DIFF
--- a/src/reporters/flat.js
+++ b/src/reporters/flat.js
@@ -4,6 +4,7 @@ const _ = require("lodash");
 const BaseReporter = require("./base");
 const helpers = require("./utils/helpers");
 const icons = require("./utils/icons");
+const { stringifyError } = require("../utils/logger");
 
 module.exports = class FlatReporter extends BaseReporter {
     constructor(...args) {
@@ -37,7 +38,7 @@ module.exports = class FlatReporter extends BaseReporter {
                 const icon = testCase.isFailed ? icons.FAIL : icons.RETRY;
 
                 this.informer.log(`   ${testCase.browserId}`);
-                this.informer.log(`     ${icon} ${testCase.error}`);
+                this.informer.log(`     ${icon} ${stringifyError(testCase.error)}`);
             });
         });
     }

--- a/src/reporters/plain.js
+++ b/src/reporters/plain.js
@@ -5,6 +5,7 @@ const chalk = require("chalk");
 const BaseReporter = require("./base");
 const icons = require("./utils/icons");
 const helpers = require("./utils/helpers");
+const { stringifyError } = require("../utils/logger");
 
 module.exports = class PlainReporter extends BaseReporter {
     _logTestInfo(test, icon) {
@@ -14,7 +15,7 @@ module.exports = class PlainReporter extends BaseReporter {
             const testInfo = helpers.getTestInfo(test);
 
             this.informer.log(`   in file ${testInfo.file}`);
-            this.informer.log(`   ${chalk.red(testInfo.error)}`);
+            this.informer.log(`   ${chalk.red(stringifyError(testInfo.error))}`);
         }
     }
 };

--- a/src/utils/logger.js
+++ b/src/utils/logger.js
@@ -9,8 +9,17 @@ const withTimestampPrefix =
         console[logFnName](`[${timestamp}]`, ...args);
     };
 
+const stringifyError = error => {
+    try {
+        return error.toString() === "[object Object]" ? JSON.stringify(error) : error;
+    } catch {
+        return error;
+    }
+};
+
 module.exports = {
     log: withTimestampPrefix("log"),
     warn: withTimestampPrefix("warn"),
     error: withTimestampPrefix("error"),
+    stringifyError,
 };


### PR DESCRIPTION
### What's done?
On rare occasions, error may be some exotic object which can't be properly stringified and is displayed as `[object Object]`. This PR changes this behaviour so that if default `toString` is not informative, `JSON.stringify()` version is displayed.