### PR TITLE
feat: generate "X-Request-ID" header for each browser request

### DIFF
--- a/README.md
+++ b/README.md
@@ -1098,6 +1098,20 @@ Allows to intercept [HTTP request options](https://github.com/sindresorhus/got#o
 (RequestOptions) => RequestOptions
 ```
 
+In runtime a unique `X-Request-ID` header is generated for each browser request which consists of `${FIRST_X_REQ_ID}__${LAST_X_REQ_ID}`, where:
+- `FIRST_X_REQ_ID` - unique uuid for each test (different for each retry), allows to find all requests related to a single test run;
+- `LAST_X_REQ_ID` - unique uuid for each browser request, allows to find one unique request in one test (together with `FIRST_X_REQ_ID`).
+
+Header `X-Request-ID` can be useful if you manage the cloud with browsers yourself and collect logs with requests. Real-world example: `2f31ffb7-369d-41f4-bbb8-77744615d2eb__e8d011d8-bb76-42b9-b80e-02f03b8d6fe1`.
+
+To override generated `X-Request-ID` to your own value you need specify it in `transformRequest` handler. Example:
+
+```javascript
+transformRequest: (req) => {
+    req.handler["X-Request-ID"] = "my_x_req_id";
+}
+```
+
 ####  transformResponse
 Allows to intercept [HTTP response object](https://github.com/sindresorhus/got#response) after a WebDriver response has arrived. Default value is `null`. If function is passed then it takes `Response` (original response object) as the first and `RequestOptions` as the second argument. Should return modified `Response`. Example:
 

--- a/README.md
+++ b/README.md
@@ -1089,7 +1089,7 @@ module.exports = (hermione) => {
 Allows to use a custom `http`/`https`/`http2` [agent](https://www.npmjs.com/package/got#agent) to make requests. Default value is `null` (it means that will be used default http-agent from got).
 
 ####  headers
-Allows to set custom [headers](https://github.com/sindresorhus/got/blob/main/documentation/2-options.md#headers) to pass into every webdriver request. These headers aren't passed into browser request. Read more about this option in [wdio](https://github.com/sindresorhus/got/blob/main/documentation/2-options.md#headers). Default value is `{'X-Request-ID': '<some-uniq-request-id>'}`. One `X-Request-ID` is generated for the entire test run. It can be useful if you manage the cloud with browsers yourself and collect logs with requests.
+Allows to set custom [headers](https://github.com/sindresorhus/got/blob/main/documentation/2-options.md#headers) to pass into every webdriver request. These headers aren't passed into browser request. Read more about this option in [wdio](https://github.com/sindresorhus/got/blob/main/documentation/2-options.md#headers). Default value is `null`.
 
 ####  transformRequest
 Allows to intercept [HTTP request options](https://github.com/sindresorhus/got#options) before a WebDriver request is made. Default value is `null`. If function is passed then it takes `RequestOptions` as the first argument and should return modified `RequestOptions`. Example:

--- a/package-lock.json
+++ b/package-lock.json
@@ -39,7 +39,6 @@
         "uglifyify": "^3.0.4",
         "urijs": "^1.19.11",
         "url-join": "^4.0.1",
-        "uuid": "^9.0.1",
         "webdriverio": "8.13.4",
         "worker-farm": "^1.7.0",
         "yallist": "^3.1.1"
@@ -4199,6 +4198,16 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
+    "node_modules/@wdio/globals/node_modules/uuid": {
+      "version": "9.0.0",
+      "resolved": "https://registry.npmjs.org/uuid/-/uuid-9.0.0.tgz",
+      "integrity": "sha512-MXcSTerfPa4uqyzStbRoTgt5XIe3x5+42+q1sDuy3R5MDk66URdLMOZe5aPX/SQd+kuYAh0FdP/pO28IkQyTeg==",
+      "optional": true,
+      "peer": true,
+      "bin": {
+        "uuid": "dist/bin/uuid"
+      }
+    },
     "node_modules/@wdio/globals/node_modules/webdriver": {
       "version": "8.16.4",
       "resolved": "https://registry.npmjs.org/webdriver/-/webdriver-8.16.4.tgz",
@@ -7466,6 +7475,14 @@
         "url": "https://github.com/chalk/strip-ansi?sponsor=1"
       }
     },
+    "node_modules/devtools/node_modules/uuid": {
+      "version": "9.0.0",
+      "resolved": "https://registry.npmjs.org/uuid/-/uuid-9.0.0.tgz",
+      "integrity": "sha512-MXcSTerfPa4uqyzStbRoTgt5XIe3x5+42+q1sDuy3R5MDk66URdLMOZe5aPX/SQd+kuYAh0FdP/pO28IkQyTeg==",
+      "bin": {
+        "uuid": "dist/bin/uuid"
+      }
+    },
     "node_modules/devtools/node_modules/which": {
       "version": "3.0.1",
       "resolved": "https://registry.npmjs.org/which/-/which-3.0.1.tgz",
@@ -10324,15 +10341,6 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/isaacs"
-      }
-    },
-    "node_modules/istanbul-lib-processinfo/node_modules/uuid": {
-      "version": "8.3.2",
-      "resolved": "https://registry.npmjs.org/uuid/-/uuid-8.3.2.tgz",
-      "integrity": "sha512-+NYs2QeMWy+GWFOEm9xnn6HCDp0l7QBD7ml8zLUmJ+93Q5NF0NocErnwkTkXVFNiX3/fpC6afS8Dhb/gz7R7eg==",
-      "dev": true,
-      "bin": {
-        "uuid": "dist/bin/uuid"
       }
     },
     "node_modules/istanbul-lib-report": {
@@ -15578,13 +15586,10 @@
       "integrity": "sha512-EPD5q1uXyFxJpCrLnCc1nHnq3gOa6DZBocAIiI2TaSCA7VCJ1UJDMagCzIkXNsUYfD1daK//LTEQ8xiIbrHtcw=="
     },
     "node_modules/uuid": {
-      "version": "9.0.1",
-      "resolved": "https://registry.npmjs.org/uuid/-/uuid-9.0.1.tgz",
-      "integrity": "sha512-b+1eJOlsR9K8HJpow9Ok3fiWOWSIcIzXodvv0rQjVoOVNpWMpxf1wZNpt4y9h10odCNrqnYp1OBzRktckBe3sA==",
-      "funding": [
-        "https://github.com/sponsors/broofa",
-        "https://github.com/sponsors/ctavan"
-      ],
+      "version": "8.3.2",
+      "resolved": "https://registry.npmjs.org/uuid/-/uuid-8.3.2.tgz",
+      "integrity": "sha512-+NYs2QeMWy+GWFOEm9xnn6HCDp0l7QBD7ml8zLUmJ+93Q5NF0NocErnwkTkXVFNiX3/fpC6afS8Dhb/gz7R7eg==",
+      "dev": true,
       "bin": {
         "uuid": "dist/bin/uuid"
       }
@@ -19521,6 +19526,13 @@
           "integrity": "sha512-pphNW/msgOUSkJbH58x8sqpq8uQj6b0ZKGxEsLKMUnGorRcDjrUaLS+39+/ub41JNTwrrMyJcUB8+YZs3mbwqw==",
           "optional": true
         },
+        "uuid": {
+          "version": "9.0.0",
+          "resolved": "https://registry.npmjs.org/uuid/-/uuid-9.0.0.tgz",
+          "integrity": "sha512-MXcSTerfPa4uqyzStbRoTgt5XIe3x5+42+q1sDuy3R5MDk66URdLMOZe5aPX/SQd+kuYAh0FdP/pO28IkQyTeg==",
+          "optional": true,
+          "peer": true
+        },
         "webdriver": {
           "version": "8.16.4",
           "resolved": "https://registry.npmjs.org/webdriver/-/webdriver-8.16.4.tgz",
@@ -22072,6 +22084,11 @@
             "ansi-regex": "^6.0.1"
           }
         },
+        "uuid": {
+          "version": "9.0.0",
+          "resolved": "https://registry.npmjs.org/uuid/-/uuid-9.0.0.tgz",
+          "integrity": "sha512-MXcSTerfPa4uqyzStbRoTgt5XIe3x5+42+q1sDuy3R5MDk66URdLMOZe5aPX/SQd+kuYAh0FdP/pO28IkQyTeg=="
+        },
         "which": {
           "version": "3.0.1",
           "resolved": "https://registry.npmjs.org/which/-/which-3.0.1.tgz",
@@ -24164,12 +24181,6 @@
           "requires": {
             "glob": "^7.1.3"
           }
-        },
-        "uuid": {
-          "version": "8.3.2",
-          "resolved": "https://registry.npmjs.org/uuid/-/uuid-8.3.2.tgz",
-          "integrity": "sha512-+NYs2QeMWy+GWFOEm9xnn6HCDp0l7QBD7ml8zLUmJ+93Q5NF0NocErnwkTkXVFNiX3/fpC6afS8Dhb/gz7R7eg==",
-          "dev": true
         }
       }
     },
@@ -28180,9 +28191,10 @@
       "integrity": "sha512-EPD5q1uXyFxJpCrLnCc1nHnq3gOa6DZBocAIiI2TaSCA7VCJ1UJDMagCzIkXNsUYfD1daK//LTEQ8xiIbrHtcw=="
     },
     "uuid": {
-      "version": "9.0.1",
-      "resolved": "https://registry.npmjs.org/uuid/-/uuid-9.0.1.tgz",
-      "integrity": "sha512-b+1eJOlsR9K8HJpow9Ok3fiWOWSIcIzXodvv0rQjVoOVNpWMpxf1wZNpt4y9h10odCNrqnYp1OBzRktckBe3sA=="
+      "version": "8.3.2",
+      "resolved": "https://registry.npmjs.org/uuid/-/uuid-8.3.2.tgz",
+      "integrity": "sha512-+NYs2QeMWy+GWFOEm9xnn6HCDp0l7QBD7ml8zLUmJ+93Q5NF0NocErnwkTkXVFNiX3/fpC6afS8Dhb/gz7R7eg==",
+      "dev": true
     },
     "v8-compile-cache-lib": {
       "version": "3.0.1",

--- a/package.json
+++ b/package.json
@@ -73,7 +73,6 @@
     "uglifyify": "^3.0.4",
     "urijs": "^1.19.11",
     "url-join": "^4.0.1",
-    "uuid": "^9.0.1",
     "webdriverio": "8.13.4",
     "worker-farm": "^1.7.0",
     "yallist": "^3.1.1"

--- a/src/browser-pool/basic-pool.js
+++ b/src/browser-pool/basic-pool.js
@@ -23,8 +23,7 @@ module.exports = class BasicPool extends Pool {
     }
 
     async getBrowser(id, opts = {}) {
-        const { version } = opts;
-        const browser = Browser.create(this._config, id, version);
+        const browser = Browser.create(this._config, { ...opts, id });
 
         try {
             await browser.init();

--- a/src/browser/existing-browser.js
+++ b/src/browser/existing-browser.js
@@ -19,14 +19,14 @@ const { isSupportIsolation } = require("../utils/browser");
 const OPTIONAL_SESSION_OPTS = ["transformRequest", "transformResponse"];
 
 module.exports = class ExistingBrowser extends Browser {
-    static create(config, id, version, emitter) {
-        return new this(config, id, version, emitter);
+    static create(config, opts) {
+        return new this(config, opts);
     }
 
-    constructor(config, id, version, emitter) {
-        super(config, id, version);
+    constructor(config, opts) {
+        super(config, opts);
 
-        this._emitter = emitter;
+        this._emitter = opts.emitter;
         this._camera = Camera.create(this._config.screenshotMode, () => this._takeScreenshot());
 
         this._meta = this._initMeta();
@@ -169,7 +169,7 @@ module.exports = class ExistingBrowser extends Browser {
         return {
             pid: process.pid,
             browserVersion: this.version,
-            "X-Request-ID": this._config.headers["X-Request-ID"],
+            testXReqId: this.testXReqId,
             ...this._config.meta,
         };
     }

--- a/src/browser/new-browser.js
+++ b/src/browser/new-browser.js
@@ -31,8 +31,8 @@ const headlessBrowserOptions = {
 };
 
 module.exports = class NewBrowser extends Browser {
-    constructor(config, id, version) {
-        super(config, id, version);
+    constructor(config, opts) {
+        super(config, opts);
 
         signalHandler.on("exit", () => this.quit());
     }

--- a/src/config/browser-options.js
+++ b/src/config/browser-options.js
@@ -2,7 +2,6 @@
 
 const _ = require("lodash");
 const option = require("gemini-configparser").option;
-const uuid = require("uuid");
 const defaults = require("./defaults");
 const optionsBuilder = require("./options-builder");
 const utils = require("./utils");
@@ -306,13 +305,7 @@ function buildBrowserOptions(defaultFactory, extra) {
         outputDir: options.optionalString("outputDir"),
 
         agent: options.optionalObject("agent"),
-        headers: option({
-            parseEnv: JSON.parse,
-            parseCli: JSON.parse,
-            defaultValue: defaultFactory("headers"),
-            validate: value => utils.assertObject(value, "headers"),
-            map: value => (value["X-Request-ID"] ? value : { "X-Request-ID": uuid.v4(), ...value }),
-        }),
+        headers: options.optionalObject("headers"),
         transformRequest: options.optionalFunction("transformRequest"),
         transformResponse: options.optionalFunction("transformResponse"),
         strictSSL: options.optionalBoolean("strictSSL"),

--- a/src/config/defaults.js
+++ b/src/config/defaults.js
@@ -83,7 +83,7 @@ module.exports = {
     fileExtensions: [".js", ".mjs", ".ts", ".mts"],
     outputDir: null,
     agent: null,
-    headers: {},
+    headers: null,
     transformRequest: null,
     transformResponse: null,
     strictSSL: null,

--- a/src/config/utils.js
+++ b/src/config/utils.js
@@ -20,12 +20,6 @@ exports.assertNonNegativeNumber = (value, name) => {
     }
 };
 
-exports.assertObject = (value, name) => {
-    if (!_.isPlainObject(value)) {
-        throw new Error(`"${name}" must be an object`);
-    }
-};
-
 exports.assertOptionalObject = (value, name) => {
     if (!_.isNull(value) && !_.isPlainObject(value)) {
         throw new Error(`"${name}" must be an object`);

--- a/src/constants/browser.ts
+++ b/src/constants/browser.ts
@@ -1,1 +1,2 @@
 export const MIN_CHROME_VERSION_SUPPORT_ISOLATION = 93;
+export const X_REQUEST_ID_DELIMITER = "__";

--- a/src/runner/browser-agent.js
+++ b/src/runner/browser-agent.js
@@ -1,11 +1,11 @@
 "use strict";
 
 module.exports = class BrowserAgent {
-    static create(id, version, pool) {
-        return new this(id, version, pool);
+    static create(opts = {}) {
+        return new this(opts);
     }
 
-    constructor(id, version, pool) {
+    constructor({ id, version, pool }) {
         this.browserId = id;
 
         this._version = version;

--- a/src/runner/browser-runner.ts
+++ b/src/runner/browser-runner.ts
@@ -60,7 +60,11 @@ export class BrowserRunner extends Runner {
     }
 
     private async _runTest(test: Test): Promise<void> {
-        const browserAgent = BrowserAgent.create(this._browserId, test.browserVersion, this.browserPool);
+        const browserAgent = BrowserAgent.create({
+            id: this._browserId,
+            version: test.browserVersion,
+            pool: this.browserPool,
+        });
         const runner = TestRunner.create(test, this.config, browserAgent);
 
         runner.on(MasterEvents.TEST_BEGIN, (test: Test) => this.suiteMonitor.testBegin(test));

--- a/src/runner/test-runner/high-priority-browser-agent.js
+++ b/src/runner/test-runner/high-priority-browser-agent.js
@@ -9,8 +9,8 @@ module.exports = class HighPriorityBrowserAgent {
         this._browserAgent = browserAgent;
     }
 
-    getBrowser() {
-        return this._browserAgent.getBrowser({ highPriority: true });
+    getBrowser(opts = {}) {
+        return this._browserAgent.getBrowser({ ...opts, highPriority: true });
     }
 
     freeBrowser(...args) {

--- a/src/runner/test-runner/regular-test-runner.js
+++ b/src/runner/test-runner/regular-test-runner.js
@@ -1,5 +1,6 @@
 "use strict";
 
+const crypto = require("crypto");
 const _ = require("lodash");
 const { Runner } = require("../runner");
 const logger = require("../../utils/logger");
@@ -64,6 +65,7 @@ module.exports = class RegularTestRunner extends Runner {
             sessionCaps: this._browser.capabilities,
             sessionOpts: this._browser.publicAPI.options,
             file: this._test.file,
+            testXReqId: this._browser.testXReqId,
         });
     }
 
@@ -80,7 +82,7 @@ module.exports = class RegularTestRunner extends Runner {
 
     async _getBrowser() {
         try {
-            this._browser = await this._browserAgent.getBrowser();
+            this._browser = await this._browserAgent.getBrowser({ testXReqId: crypto.randomUUID() });
             this._test.sessionId = this._browser.sessionId;
 
             return this._browser;

--- a/src/worker/hermione.ts
+++ b/src/worker/hermione.ts
@@ -11,6 +11,7 @@ export interface WorkerRunTestOpts {
     sessionId: string;
     sessionCaps: WdioBrowser["capabilities"];
     sessionOpts: WdioBrowser["options"];
+    testXReqId: string;
 }
 
 export interface AssertViewResultsSuccess {

--- a/src/worker/runner/browser-agent.js
+++ b/src/worker/runner/browser-agent.js
@@ -1,24 +1,25 @@
 "use strict";
 
 module.exports = class BrowserAgent {
-    static create(browserId, browserVersion, pool) {
-        return new BrowserAgent(browserId, browserVersion, pool);
+    static create(opts) {
+        return new this(opts);
     }
 
-    constructor(browserId, browserVersion, pool) {
-        this.browserId = browserId;
-        this.browserVersion = browserVersion;
+    constructor({ id, version, pool }) {
+        this.browserId = id;
+        this.browserVersion = version;
 
         this._pool = pool;
     }
 
-    getBrowser({ sessionId, sessionCaps, sessionOpts }) {
+    getBrowser({ sessionId, sessionCaps, sessionOpts, testXReqId }) {
         return this._pool.getBrowser({
             browserId: this.browserId,
             browserVersion: this.browserVersion,
             sessionId,
             sessionCaps,
             sessionOpts,
+            testXReqId,
         });
     }
 

--- a/src/worker/runner/browser-pool.js
+++ b/src/worker/runner/browser-pool.js
@@ -16,8 +16,13 @@ module.exports = class BrowserPool {
         this._calibrator = new Calibrator();
     }
 
-    async getBrowser({ browserId, browserVersion, sessionId, sessionCaps, sessionOpts }) {
-        const browser = Browser.create(this._config, browserId, browserVersion, this._emitter);
+    async getBrowser({ browserId, browserVersion, sessionId, sessionCaps, sessionOpts, testXReqId }) {
+        const browser = Browser.create(this._config, {
+            id: browserId,
+            version: browserVersion,
+            testXReqId,
+            emitter: this._emitter,
+        });
 
         try {
             await browser.init({ sessionId, sessionCaps, sessionOpts }, this._calibrator);

--- a/src/worker/runner/index.js
+++ b/src/worker/runner/index.js
@@ -27,12 +27,12 @@ module.exports = class Runner extends AsyncEmitter {
         ]);
     }
 
-    async runTest(fullTitle, { browserId, browserVersion, file, sessionId, sessionCaps, sessionOpts }) {
+    async runTest(fullTitle, { browserId, browserVersion, file, sessionId, sessionCaps, sessionOpts, testXReqId }) {
         const tests = await this._testParser.parse({ file, browserId });
         const test = tests.find(t => t.fullTitle() === fullTitle);
-        const browserAgent = BrowserAgent.create(browserId, browserVersion, this._browserPool);
+        const browserAgent = BrowserAgent.create({ id: browserId, version: browserVersion, pool: this._browserPool });
         const runner = TestRunner.create(test, this._config.forBrowser(browserId), browserAgent);
 
-        return runner.run({ sessionId, sessionCaps, sessionOpts });
+        return runner.run({ sessionId, sessionCaps, sessionOpts, testXReqId });
     }
 };

--- a/src/worker/runner/test-runner/index.js
+++ b/src/worker/runner/test-runner/index.js
@@ -22,14 +22,14 @@ module.exports = class TestRunner {
         this._browserAgent = browserAgent;
     }
 
-    async run({ sessionId, sessionCaps, sessionOpts }) {
+    async run({ sessionId, sessionCaps, sessionOpts, testXReqId }) {
         const test = this._test;
         const hermioneCtx = test.hermioneCtx || {};
 
         let browser;
 
         try {
-            browser = await this._browserAgent.getBrowser({ sessionId, sessionCaps, sessionOpts });
+            browser = await this._browserAgent.getBrowser({ sessionId, sessionCaps, sessionOpts, testXReqId });
         } catch (e) {
             throw Object.assign(e, { hermioneCtx });
         }

--- a/test/src/browser-pool/basic-pool.js
+++ b/test/src/browser-pool/basic-pool.js
@@ -33,13 +33,13 @@ describe("browser-pool/basic-pool", () => {
 
         await mkPool_({ config }).getBrowser("broId");
 
-        assert.calledWith(Browser.create, config, "broId");
+        assert.calledWith(Browser.create, config, { id: "broId" });
     });
 
     it("should create new browser with specified version when requested", async () => {
         await mkPool_().getBrowser("broId", { version: "1.0" });
 
-        assert.calledWith(Browser.create, sinon.match.any, "broId", "1.0");
+        assert.calledWith(Browser.create, sinon.match.any, { id: "broId", version: "1.0" });
     });
 
     it("should init browser", async () => {

--- a/test/src/browser/existing-browser.js
+++ b/test/src/browser/existing-browser.js
@@ -74,12 +74,6 @@ describe("ExistingBrowser", () => {
                 assert.propertyVal(browser.meta, "browserVersion", "10.1");
             });
 
-            it("should extend meta-info with 'X-Request-ID' from headers", () => {
-                const browser = mkBrowser_({ headers: { "X-Request-ID": "uniq-req-id" } });
-
-                assert.propertyVal(browser.meta, "X-Request-ID", "uniq-req-id");
-            });
-
             it("should set meta-info with provided meta option", () => {
                 const browser = mkBrowser_({ meta: { k1: "v1" } });
 

--- a/test/src/browser/new-browser.js
+++ b/test/src/browser/new-browser.js
@@ -36,7 +36,6 @@ describe("NewBrowser", () => {
                 connectionRetryTimeout: 3000,
                 connectionRetryCount: 0,
                 baseUrl: "http://base_url",
-                headers: {},
             });
         });
 

--- a/test/src/browser/utils.js
+++ b/test/src/browser/utils.js
@@ -29,7 +29,7 @@ function createBrowserConfig_(opts = {}) {
         },
         waitOrientationChange: true,
         agent: null,
-        headers: {},
+        headers: null,
         transformRequest: null,
         transformResponse: null,
         strictSSL: null,

--- a/test/src/browser/utils.js
+++ b/test/src/browser/utils.js
@@ -49,12 +49,15 @@ function createBrowserConfig_(opts = {}) {
     };
 }
 
-exports.mkNewBrowser_ = (opts, browser = "browser", version) => {
-    return NewBrowser.create(createBrowserConfig_(opts), browser, version);
+exports.mkNewBrowser_ = (configOpts, opts = { id: "browser", version: "1.0", testXReqId: "" }) => {
+    return NewBrowser.create(createBrowserConfig_(configOpts), opts);
 };
 
-exports.mkExistingBrowser_ = (opts, browser = "browser", browserVersion, emitter = "emitter") => {
-    return ExistingBrowser.create(createBrowserConfig_(opts), browser, browserVersion, emitter);
+exports.mkExistingBrowser_ = (
+    configOpts,
+    opts = { id: "browser", version: "1.0", testXReqId: "", emitter: "emitter" },
+) => {
+    return ExistingBrowser.create(createBrowserConfig_(configOpts), opts);
 };
 
 exports.mkMockStub_ = () => {

--- a/test/src/config/browser-options.js
+++ b/test/src/config/browser-options.js
@@ -1,6 +1,7 @@
 "use strict";
 
 const _ = require("lodash");
+
 const { Config } = require("src/config");
 const defaults = require("src/config/defaults");
 const { WEBDRIVER_PROTOCOL, DEVTOOLS_PROTOCOL, SAVE_HISTORY_MODE } = require("src/constants/config");
@@ -1625,74 +1626,33 @@ describe("config browser-options", () => {
         });
     });
 
-    describe("agent", () => {
-        it(`should throw error if "agent" is not an object`, () => {
-            const readConfig = _.set({}, "browsers.b1", mkBrowser_({ agent: "string" }));
+    ["agent", "headers"].forEach(option => {
+        describe(option, () => {
+            it(`should throw error if "${option}" is not an object`, () => {
+                const readConfig = _.set({}, "browsers.b1", mkBrowser_({ [option]: "string" }));
 
-            Config.read.returns(readConfig);
+                Config.read.returns(readConfig);
 
-            assert.throws(() => createConfig(), Error, `"agent" must be an object`);
-        });
+                assert.throws(() => createConfig(), Error, `"${option}" must be an object`);
+            });
 
-        it("should set a default value if it is not set in config", () => {
-            const readConfig = _.set({}, "browsers.b1", mkBrowser_());
-            Config.read.returns(readConfig);
-
-            const config = createConfig();
-
-            assert.equal(config.agent, defaults.option);
-        });
-
-        it("should set provided value", () => {
-            const readConfig = _.set({}, "browsers.b1", mkBrowser_({ agent: { k1: "v1", k2: "v2" } }));
-            Config.read.returns(readConfig);
-
-            const config = createConfig();
-
-            assert.deepEqual(config.browsers.b1.agent, { k1: "v1", k2: "v2" });
-        });
-    });
-
-    describe("headers", () => {
-        it("should throw error if option is not an object", () => {
-            const readConfig = _.set({}, "browsers.b1", mkBrowser_({ headers: null }));
-
-            Config.read.returns(readConfig);
-
-            assert.throws(() => createConfig(), Error, `"headers" must be an object`);
-        });
-
-        describe("should generate 'X-Request-ID'", () => {
-            it("if value is not set in config", () => {
+            it("should set a default value if it is not set in config", () => {
                 const readConfig = _.set({}, "browsers.b1", mkBrowser_());
                 Config.read.returns(readConfig);
 
                 const config = createConfig();
 
-                assert.typeOf(config.browsers.b1.headers["X-Request-ID"], "string");
-                assert.isAbove(config.browsers.b1.headers["X-Request-ID"].length, 20);
+                assert.equal(config[option], defaults[option]);
             });
 
-            it("if it is not specified in value", () => {
-                const readConfig = _.set({}, "browsers.b1", mkBrowser_({ headers: { k1: "v1" } }));
+            it("should set provided value", () => {
+                const readConfig = _.set({}, "browsers.b1", mkBrowser_({ [option]: { k1: "v1", k2: "v2" } }));
                 Config.read.returns(readConfig);
 
                 const config = createConfig();
 
-                assert.typeOf(config.browsers.b1.headers["X-Request-ID"], "string");
-                assert.isAbove(config.browsers.b1.headers["X-Request-ID"].length, 20);
-                assert.equal(config.browsers.b1.headers.k1, "v1");
+                assert.deepEqual(config.browsers.b1[option], { k1: "v1", k2: "v2" });
             });
-        });
-
-        it("should not generate 'X-Request-ID' if it is specified by user", () => {
-            const headers = { "X-Request-ID": "my-req-id" };
-            const readConfig = _.set({}, "browsers.b1", mkBrowser_({ headers }));
-            Config.read.returns(readConfig);
-
-            const config = createConfig();
-
-            assert.deepEqual(config.browsers.b1.headers, headers);
         });
     });
 

--- a/test/src/runner/browser-agent.js
+++ b/test/src/runner/browser-agent.js
@@ -11,7 +11,7 @@ describe("runner/browser-agent", () => {
         version = version || "some.default.version";
         pool = pool || Object.create(BrowserPool.prototype);
 
-        return BrowserAgent.create(id, version, pool);
+        return BrowserAgent.create({ id, version, pool });
     }
 
     function mkBrowser_(opts = {}) {

--- a/test/src/runner/browser-runner.js
+++ b/test/src/runner/browser-runner.js
@@ -155,8 +155,8 @@ describe("runner/browser-runner", () => {
             await run_({ runner });
 
             assert.calledTwice(BrowserAgent.create);
-            assert.calledWith(BrowserAgent.create.firstCall, "bro", "1.0", pool);
-            assert.calledWith(BrowserAgent.create.secondCall, "bro", "1.0", pool);
+            assert.calledWith(BrowserAgent.create.firstCall, { id: "bro", version: "1.0", pool });
+            assert.calledWith(BrowserAgent.create.secondCall, { id: "bro", version: "1.0", pool });
         });
 
         it("should create test runner for each test in collection", async () => {

--- a/test/src/runner/test-runner/high-priority-browser-agent.js
+++ b/test/src/runner/test-runner/high-priority-browser-agent.js
@@ -5,13 +5,13 @@ const HighPriorityBrowserAgent = require("src/runner/test-runner/high-priority-b
 
 describe("runner/test-runner/high-priority-browser-agent", () => {
     describe("getBrowser", () => {
-        it("should call base browser agent getBrowser with highPriority option", () => {
+        it("should call base browser agent getBrowser with p highPriority option", () => {
             const browserAgent = sinon.createStubInstance(BrowserAgent);
             const highPriorityBrowserAgent = HighPriorityBrowserAgent.create(browserAgent);
 
-            highPriorityBrowserAgent.getBrowser();
+            highPriorityBrowserAgent.getBrowser({ foo: "bar" });
 
-            assert.calledOnceWith(browserAgent.getBrowser, { highPriority: true });
+            assert.calledOnceWith(browserAgent.getBrowser, { foo: "bar", highPriority: true });
         });
 
         it("should return base browser agent getBrowser result", () => {

--- a/test/src/runner/test-runner/regular-test-runner.js
+++ b/test/src/runner/test-runner/regular-test-runner.js
@@ -1,5 +1,6 @@
 "use strict";
 
+const crypto = require("crypto");
 const _ = require("lodash");
 
 const BrowserAgent = require("src/runner/browser-agent");
@@ -32,7 +33,7 @@ describe("runner/test-runner/regular-test-runner", () => {
 
     const mkRunner_ = (opts = {}) => {
         const test = opts.test || new Test({ title: "defaultTest" });
-        const browserAgent = opts.browserAgent || BrowserAgent.create();
+        const browserAgent = opts.browserAgent || BrowserAgent.create({});
 
         return RegularTestRunner.create(test, browserAgent);
     };
@@ -70,6 +71,7 @@ describe("runner/test-runner/regular-test-runner", () => {
         sandbox.stub(AssertViewResults.prototype, "get").returns({});
 
         sandbox.stub(logger, "warn");
+        sandbox.stub(crypto, "randomUUID").returns("");
     });
 
     afterEach(() => sandbox.restore());
@@ -87,7 +89,9 @@ describe("runner/test-runner/regular-test-runner", () => {
 
     describe("run", () => {
         it("should get browser before running test", async () => {
-            BrowserAgent.prototype.getBrowser.resolves(
+            const testXReqId = "12345";
+            crypto.randomUUID.returns(testXReqId);
+            BrowserAgent.prototype.getBrowser.withArgs({ testXReqId }).resolves(
                 stubBrowser_({
                     id: "bro",
                     version: "1.0",
@@ -96,6 +100,7 @@ describe("runner/test-runner/regular-test-runner", () => {
                     publicAPI: {
                         options: { foo: "bar" },
                     },
+                    testXReqId,
                 }),
             );
             const workers = mkWorkers_();
@@ -111,6 +116,7 @@ describe("runner/test-runner/regular-test-runner", () => {
                     sessionId: "100500",
                     sessionCaps: { browserName: "bro" },
                     sessionOpts: { foo: "bar" },
+                    testXReqId,
                 }),
             );
         });

--- a/test/src/worker/runner/browser-agent.js
+++ b/test/src/worker/runner/browser-agent.js
@@ -17,14 +17,16 @@ describe("worker/browser-agent", () => {
                     sessionId: "100-500",
                     sessionCaps: "some-caps",
                     sessionOpts: "some-opts",
+                    testXReqId: "12345",
                 })
                 .returns({ some: "browser" });
-            const browserAgent = BrowserAgent.create("bro-id", null, browserPool);
+            const browserAgent = BrowserAgent.create({ id: "bro-id", version: null, pool: browserPool });
 
             const browser = browserAgent.getBrowser({
                 sessionId: "100-500",
                 sessionCaps: "some-caps",
                 sessionOpts: "some-opts",
+                testXReqId: "12345",
             });
 
             assert.deepEqual(browser, { some: "browser" });
@@ -38,14 +40,16 @@ describe("worker/browser-agent", () => {
                     sessionId: "100-500",
                     sessionCaps: "some-caps",
                     sessionOpts: "some-opts",
+                    testXReqId: "12345",
                 })
                 .returns({ some: "browser" });
-            const browserAgent = BrowserAgent.create("bro-id", "10.1", browserPool);
+            const browserAgent = BrowserAgent.create({ id: "bro-id", version: "10.1", pool: browserPool });
 
             const browser = browserAgent.getBrowser({
                 sessionId: "100-500",
                 sessionCaps: "some-caps",
                 sessionOpts: "some-opts",
+                testXReqId: "12345",
             });
 
             assert.deepEqual(browser, { some: "browser" });
@@ -54,7 +58,7 @@ describe("worker/browser-agent", () => {
 
     describe("freeBrowser", () => {
         it("should free the browser in the pool", () => {
-            BrowserAgent.create(null, null, browserPool).freeBrowser({ some: "browser" });
+            BrowserAgent.create({ pool: browserPool }).freeBrowser({ some: "browser" });
 
             assert.calledOnceWith(browserPool.freeBrowser, { some: "browser" });
         });

--- a/test/src/worker/runner/browser-pool.js
+++ b/test/src/worker/runner/browser-pool.js
@@ -52,24 +52,16 @@ describe("worker/browser-pool", () => {
             const config = stubConfig();
             const emitter = new EventEmitter();
             const browserPool = createPool({ config, emitter });
-            const browser = stubBrowser({ browserId: "bro-id" });
-            Browser.create.withArgs(config, "bro-id", undefined, emitter).returns(browser);
+            Browser.create.returns(stubBrowser({ browserId: "bro-id" }));
 
-            await browserPool.getBrowser({ browserId: "bro-id" });
+            await browserPool.getBrowser({ browserId: "bro-id", browserVersion: "1.0", testXReqId: "12345" });
 
-            assert.calledOnceWith(Browser.create, config, "bro-id", undefined, emitter);
-        });
-
-        it("should create specific version of browser with correct args", async () => {
-            const config = stubConfig();
-            const emitter = new EventEmitter();
-            const browserPool = createPool({ config, emitter });
-            const browser = stubBrowser({ browserId: "bro-id" });
-            Browser.create.withArgs(config, "bro-id", "10.1", emitter).returns(browser);
-
-            await browserPool.getBrowser({ browserId: "bro-id", browserVersion: "10.1" });
-
-            assert.calledOnceWith(Browser.create, config, "bro-id", "10.1", emitter);
+            assert.calledOnceWith(Browser.create, config, {
+                id: "bro-id",
+                version: "1.0",
+                testXReqId: "12345",
+                emitter,
+            });
         });
 
         it("should init a new created browser ", async () => {
@@ -108,20 +100,9 @@ describe("worker/browser-pool", () => {
             const config = stubConfig();
             const browserPool = createPool({ config });
             const browser = stubBrowser({ browserId: "bro-id" });
-
-            Browser.create.withArgs(config, "bro-id").returns(browser);
+            Browser.create.returns(browser);
 
             return assert.becomes(browserPool.getBrowser({ browserId: "bro-id" }), browser);
-        });
-
-        it("should return a new createt browser with specific version", () => {
-            const config = stubConfig();
-            const browserPool = createPool({ config });
-            const browser = stubBrowser({ browserId: "bro-id" });
-
-            Browser.create.withArgs(config, "bro-id", "10.1").returns(browser);
-
-            return assert.becomes(browserPool.getBrowser({ browserId: "bro-id", browserVersion: "10.1" }), browser);
         });
 
         describe("getting of browser fails", () => {

--- a/test/src/worker/runner/index.js
+++ b/test/src/worker/runner/index.js
@@ -93,15 +93,17 @@ describe("worker/runner", () => {
         });
 
         it("should create browser agent for test runner", async () => {
+            const pool = { browser: "pool" };
+            BrowserPool.create.returns(pool);
             const runner = mkRunner_();
 
             const test = makeTest({ fullTitle: () => "some test" });
             CachingTestParser.prototype.parse.resolves([test]);
 
             const browserAgent = Object.create(BrowserAgent.prototype);
-            BrowserAgent.create.withArgs("bro").returns(browserAgent);
+            BrowserAgent.create.withArgs({ id: "bro", version: "1.0", pool }).returns(browserAgent);
 
-            await runner.runTest("some test", { browserId: "bro" });
+            await runner.runTest("some test", { browserId: "bro", browserVersion: "1.0" });
 
             assert.calledOnceWith(TestRunner.create, test, sinon.match.any, browserAgent);
         });
@@ -128,12 +130,14 @@ describe("worker/runner", () => {
                 sessionId: "100500",
                 sessionCaps: "some-caps",
                 sessionOpts: "some-opts",
+                testXReqId: "12345",
             });
 
             assert.calledOnceWith(TestRunner.prototype.run, {
                 sessionId: "100500",
                 sessionCaps: "some-caps",
                 sessionOpts: "some-opts",
+                testXReqId: "12345",
             });
         });
     });

--- a/test/src/worker/runner/test-runner/index.js
+++ b/test/src/worker/runner/test-runner/index.js
@@ -106,7 +106,12 @@ describe("worker/runner/test-runner", () => {
 
         it("should request browser for passed session", async () => {
             const runner = mkRunner_();
-            const opts = { sessionId: "100500", sessionCaps: "some-caps", sessionOpts: "some-opts" };
+            const opts = {
+                sessionId: "100500",
+                sessionCaps: "some-caps",
+                sessionOpts: "some-opts",
+                testXReqId: "12345",
+            };
 
             await runner.run(opts);
 


### PR DESCRIPTION
### What is done

For each browser request hermione generates uniq `X-Request-ID` header which consists of `${TEST_X_REQ_ID}${DELIMITER}$BROWSER_X_REQ_ID}`, where:
- `TEST_X_REQ_ID` - uniq uuid for each test (different from every other test retry), allows you to find all requests related to a single test run using logs
- `DELIMITER` - `__` separator between test and request uuids
- `BROWSER_X_REQ_ID` - uniq uuid for each browser request

Real-world example: `2f31ffb7-369d-41f4-bbb8-77744615d2eb__e8d011d8-bb76-42b9-b80e-02f03b8d6fe1`.

Moreover revert previous decision in beta version with generate the same `X-Request-ID` for each request in whole hermione run.