### PR TITLE
feat: add ability to use devtools procotol through cli option

### DIFF
--- a/src/browser/new-browser.js
+++ b/src/browser/new-browser.js
@@ -8,6 +8,8 @@ const Browser = require("./browser");
 const signalHandler = require("../signal-handler");
 const history = require("./history");
 const logger = require("../utils/logger");
+const RuntimeConfig = require("../config/runtime-config");
+const { DEVTOOLS_PROTOCOL } = require("../constants/config");
 
 const DEFAULT_PORT = 4444;
 
@@ -92,6 +94,7 @@ module.exports = class NewBrowser extends Browser {
         const config = this._config;
         const gridUri = new URI(config.gridUrl);
         const capabilities = this._extendCapabilities(config);
+        const { devtools } = RuntimeConfig.getInstance();
 
         const options = {
             protocol: gridUri.protocol(),
@@ -100,7 +103,7 @@ module.exports = class NewBrowser extends Browser {
             path: gridUri.path(),
             queryParams: this._getQueryParams(gridUri.query()),
             capabilities,
-            automationProtocol: config.automationProtocol,
+            automationProtocol: devtools ? DEVTOOLS_PROTOCOL : config.automationProtocol,
             connectionRetryTimeout: config.sessionRequestTimeout || config.httpTimeout,
             connectionRetryCount: 0, // hermione has its own advanced retries
             baseUrl: config.baseUrl,

--- a/src/cli/index.js
+++ b/src/cli/index.js
@@ -67,6 +67,7 @@ exports.run = () => {
         )
         .option("--repl-before-test [type]", "open repl interface before test run", Boolean, false)
         .option("--repl-on-fail [type]", "open repl interface on test fail only", Boolean, false)
+        .option("--devtools", "switches the browser to the devtools mode with using CDP protocol")
         .arguments("[paths...]")
         .action(async paths => {
             try {
@@ -82,6 +83,7 @@ exports.run = () => {
                     repl,
                     replBeforeTest,
                     replOnFail,
+                    devtools,
                 } = program;
 
                 await handleRequires(requireModules);
@@ -99,6 +101,7 @@ exports.run = () => {
                         beforeTest: replBeforeTest,
                         onFail: replOnFail,
                     },
+                    devtools: devtools || false,
                 });
 
                 process.exit(isTestsSuccess ? 0 : 1);

--- a/src/hermione.ts
+++ b/src/hermione.ts
@@ -31,6 +31,7 @@ interface RunOpts {
         beforeTest: boolean;
         onFail: boolean;
     };
+    devtools: boolean;
 }
 
 interface ReadTestsOpts extends Pick<RunOpts, "browsers" | "sets" | "grep" | "replMode"> {
@@ -69,12 +70,13 @@ export class Hermione extends BaseHermione {
             requireModules,
             inspectMode,
             replMode,
+            devtools,
             reporters = [],
         }: Partial<RunOpts> = {},
     ): Promise<boolean> {
         validateUnknownBrowsers(browsers, _.keys(this._config.browsers));
 
-        RuntimeConfig.getInstance().extend({ updateRefs, requireModules, inspectMode, replMode });
+        RuntimeConfig.getInstance().extend({ updateRefs, requireModules, inspectMode, replMode, devtools });
 
         if (replMode?.enabled) {
             this._config.system.mochaOpts.timeout = 0;

--- a/test/src/cli/index.js
+++ b/test/src/cli/index.js
@@ -280,4 +280,10 @@ describe("cli", () => {
             });
         });
     });
+
+    it("should turn on devtools mode from cli", async () => {
+        await run_("--devtools");
+
+        assert.calledWithMatch(Hermione.prototype.run, any, { devtools: true });
+    });
 });

--- a/test/src/hermione.js
+++ b/test/src/hermione.js
@@ -188,6 +188,7 @@ describe("hermione", () => {
                 replMode: {
                     enabled: true,
                 },
+                devtools: true,
             });
 
             assert.calledOnce(RuntimeConfig.getInstance);
@@ -196,6 +197,7 @@ describe("hermione", () => {
                 requireModules: ["foo"],
                 inspectMode: { inspect: true },
                 replMode: { enabled: true },
+                devtools: true,
             });
             assert.callOrder(RuntimeConfig.getInstance, Runner.create);
         });


### PR DESCRIPTION
### What is done

add ability to use devtools procotol through cli option `--devtools` in order to make it easier to switch between the two protocols (`devtools` and `webdriver`).