### PR TITLE
chore(npm): removed @types/chalk

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -10,7 +10,6 @@
       "license": "MIT",
       "dependencies": {
         "@gemini-testing/commander": "2.15.3",
-        "@types/chalk": "2.2.0",
         "@types/mocha": "10.0.1",
         "@wdio/globals": "8.21.0",
         "@wdio/types": "8.21.0",
@@ -2104,15 +2103,6 @@
       "dev": true,
       "dependencies": {
         "@types/chai": "*"
-      }
-    },
-    "node_modules/@types/chalk": {
-      "version": "2.2.0",
-      "resolved": "https://registry.npmjs.org/@types/chalk/-/chalk-2.2.0.tgz",
-      "integrity": "sha512-1zzPV9FDe1I/WHhRkf9SNgqtRJWZqrBWgu7JGveuHmmyR9CnAPCie2N/x+iHrgnpYBIcCJWHBoMRv2TRWktsvw==",
-      "deprecated": "This is a stub types definition for chalk (https://github.com/chalk/chalk). chalk provides its own type definitions, so you don't need @types/chalk installed!",
-      "dependencies": {
-        "chalk": "*"
       }
     },
     "node_modules/@types/http-cache-semantics": {
@@ -18058,14 +18048,6 @@
       "dev": true,
       "requires": {
         "@types/chai": "*"
-      }
-    },
-    "@types/chalk": {
-      "version": "2.2.0",
-      "resolved": "https://registry.npmjs.org/@types/chalk/-/chalk-2.2.0.tgz",
-      "integrity": "sha512-1zzPV9FDe1I/WHhRkf9SNgqtRJWZqrBWgu7JGveuHmmyR9CnAPCie2N/x+iHrgnpYBIcCJWHBoMRv2TRWktsvw==",
-      "requires": {
-        "chalk": "*"
       }
     },
     "@types/http-cache-semantics": {

--- a/package.json
+++ b/package.json
@@ -45,7 +45,6 @@
   "license": "MIT",
   "dependencies": {
     "@gemini-testing/commander": "2.15.3",
-    "@types/chalk": "2.2.0",
     "@types/mocha": "10.0.1",
     "@wdio/globals": "8.21.0",
     "@wdio/types": "8.21.0",


### PR DESCRIPTION
```
npm WARN deprecated @types/chalk@2.2.0: This is a stub types definition for chalk (https://github.com/chalk/chalk). chalk provides its own type definitions, so you don't need @types/chalk installed!
```