### PR TITLE
fix: extend AssertViewResultDiff type

### DIFF
--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -79,6 +79,8 @@ export interface AssertViewResultDiff {
     refImg: ImageInfo;
     stack: string;
     stateName: string;
+    differentPixels: number;
+    diffRatio: number;
 }
 
 export interface AssertViewResultNoRefImage {


### PR DESCRIPTION
## What is done
- added missing typings for `differentPixels` and `diffRatio` fields