### PR TITLE
fix: correctly screen elements inside iframes

### DIFF
--- a/src/browser/client-scripts/index.js
+++ b/src/browser/client-scripts/index.js
@@ -70,10 +70,11 @@ function prepareScreenshotUnsafe(areas, opts) {
         }
     }
 
-    var viewportWidth = document.documentElement.clientWidth,
-        viewportHeight = document.documentElement.clientHeight,
-        documentWidth = document.documentElement.scrollWidth,
-        documentHeight = document.documentElement.scrollHeight,
+    var mainDocumentElem = util.getMainDocumentElem(),
+        viewportWidth = mainDocumentElem.clientWidth,
+        viewportHeight = mainDocumentElem.clientHeight,
+        documentWidth = mainDocumentElem.scrollWidth,
+        documentHeight = mainDocumentElem.scrollHeight,
         viewPort = new Rect({
             left: util.getScrollLeft(scrollElem),
             top: util.getScrollTop(scrollElem),
@@ -381,8 +382,9 @@ function isEditable(element) {
 }
 
 function scrollToCaptureAreaInSafari(viewportCurr, captureArea, scrollElem) {
-    var documentHeight = Math.round(document.documentElement.scrollHeight);
-    var viewportHeight = Math.round(document.documentElement.clientHeight);
+    var mainDocumentElem = util.getMainDocumentElem();
+    var documentHeight = Math.round(mainDocumentElem.scrollHeight);
+    var viewportHeight = Math.round(mainDocumentElem.clientHeight);
     var maxScrollByY = documentHeight - viewportHeight;
 
     scrollElem.scrollTo(viewportCurr.left, Math.min(captureArea.top, maxScrollByY));

--- a/src/browser/client-scripts/util.js
+++ b/src/browser/client-scripts/util.js
@@ -105,3 +105,38 @@ exports.forEachRoot = function (cb) {
 
     traverseRoots(document.documentElement);
 };
+
+exports.getOwnerWindow = function (node) {
+    if (!node.ownerDocument) {
+        return null;
+    }
+
+    return node.ownerDocument.defaultView;
+};
+
+exports.getOwnerIframe = function (node) {
+    var nodeWindow = exports.getOwnerWindow(node);
+    if (nodeWindow) {
+        return nodeWindow.frameElement;
+    }
+
+    return null;
+};
+
+exports.getMainDocumentElem = function (currDocumentElem) {
+    if (!currDocumentElem) {
+        currDocumentElem = document.documentElement;
+    }
+
+    var currIframe = exports.getOwnerIframe(currDocumentElem);
+    if (!currIframe) {
+        return currDocumentElem;
+    }
+
+    var currWindow = exports.getOwnerWindow(currIframe);
+    if (!currWindow) {
+        return currDocumentElem;
+    }
+
+    return exports.getMainDocumentElem(currWindow.document.documentElement);
+};


### PR DESCRIPTION
## What is done

`getBoundingClientRect` inside iframe returns DOMRect only inside this iframe and don't know nothing about offsets between this iframe and viewport. Therefore, a solution has been implemented that takes into account the indentation of the iframe

Fix issue - https://github.com/gemini-testing/hermione/issues/349 



