### PR TITLE
feat: add ability to use default export in .hermione.conf file

### DIFF
--- a/src/config/index.ts
+++ b/src/config/index.ts
@@ -15,7 +15,10 @@ export class Config {
 
     static read(configPath: string): unknown {
         try {
-            return require(path.resolve(process.cwd(), configPath));
+            // eslint-disable-next-line @typescript-eslint/no-var-requires
+            const configModule = require(path.resolve(process.cwd(), configPath));
+
+            return configModule.__esModule ? configModule.default : configModule;
         } catch (e) {
             logger.error(`Unable to read config from path ${configPath}`);
             throw e;

--- a/test/src/config/index.js
+++ b/test/src/config/index.js
@@ -43,6 +43,12 @@ describe("config", () => {
             assert.calledWithMatch(parseOptions, { options: "some-options", env: process.env, argv: process.argv });
         });
 
+        it("should support default export", () => {
+            initConfig({ requireConfigReturns: { __esModule: true, default: { foo: "bar" } } });
+
+            assert.calledWithMatch(parseOptions, { options: { foo: "bar" }, env: process.env, argv: process.argv });
+        });
+
         it("should parse config from object", () => {
             initConfig({ config: { someOption: "some-value" } });
 


### PR DESCRIPTION
## What is done
- add ability to use `export default` in `.hermione.conf.(j|t)s` file. At the moment `.ts` config has to be `export =`