### PR TITLE
fix: add getConfig command typings

### DIFF
--- a/src/browser/types.ts
+++ b/src/browser/types.ts
@@ -26,6 +26,8 @@ declare global {
 
             extendOptions(opts: { [name: string]: unknown }): Promise<void>;
 
+            getConfig(): Promise<BrowserConfig>;
+
             /**
              * Takes a screenshot of the passed selector and compares the received screenshot with the reference.
              *


### PR DESCRIPTION
## What is done
- Add `browser.getConfig` typings