### PR TITLE
fix: fix conflicting overwriteCommand type definition

### DIFF
--- a/src/browser/types.ts
+++ b/src/browser/types.ts
@@ -22,7 +22,7 @@ declare global {
     namespace WebdriverIO {
         type OverwriteCommandFn<IsElement extends boolean = false> = (
             this: IsElement extends true ? WebdriverIO.Element : WebdriverIO.Browser,
-            origCommand: (...args: any[]) => Promise<any>, // eslint-disable-line @typescript-eslint/no-explicit-any
+            origCommand: (...args: any[]) => any, // eslint-disable-line @typescript-eslint/no-explicit-any
             ...args: any[] // eslint-disable-line @typescript-eslint/no-explicit-any
         ) => Promise<any>; // eslint-disable-line @typescript-eslint/no-explicit-any
 


### PR DESCRIPTION
Existing `overwriteCommand` definition conflicts with wdio's definition due to an incompatibility between `origCommand` types: wdio's definition has return type of `Promise<... | never>`, while ours has `Promise<any>`. Since never is not assignable to any, it doesn't work. This PR replaces `Promise<any>` with just `any`.