### PR TITLE
feat: add ability to extend "hermione" global variable

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -10,7 +10,16 @@ import { GlobalHelper } from "./types";
 export { Hermione as default } from "./hermione";
 export { Key } from "webdriverio";
 
-export type { WdioBrowser, TestResult, Test, Suite, TestError, AssertViewOpts, HermioneCtx } from "./types";
+export type {
+    WdioBrowser,
+    TestResult,
+    Test,
+    Suite,
+    TestError,
+    AssertViewOpts,
+    HermioneCtx,
+    GlobalHelper,
+} from "./types";
 export type { Config } from "./config";
 export type { ConfigInput } from "./config/types";
 export type { TestCollection } from "./test-collection";


### PR DESCRIPTION
## Usage example

- Extend interface `GlobalHelper` from module "hermione":
```ts
// global.d.ts
import type { GlobalHelper } from "hermione";

declare module "hermione" {
  interface GlobalHelper {
    also: {
        in: (args: string | string[]) => void;
    };
  }
}
```
- Use `hermione.also.in` with extended typings:
```ts
hermione.also.in('foo');
```
